### PR TITLE
Swizzling Fix

### DIFF
--- a/OneSignalExample/Assets/OneSignal/Platforms/iOS/OneSignalUnityRuntime.m
+++ b/OneSignalExample/Assets/OneSignal/Platforms/iOS/OneSignalUnityRuntime.m
@@ -117,8 +117,10 @@ static OSUnityPermissionAndSubscriptionObserver* osUnityObserver;
 static Class delegateClass = nil;
 
 - (void) setOneSignalUnityDelegate:(id<UIApplicationDelegate>)delegate {
-    if(delegateClass != nil)
+    if(delegateClass) {
+        [self setOneSignalUnityDelegate:delegate];
         return;
+    }
     
     delegateClass = getClassWithProtocolInHierarchy([delegate class], @protocol(UIApplicationDelegate));
     


### PR DESCRIPTION
• Fixes an issue where a swizzled implementation of the UNUserNotificationCenter.setDelegate() method was not calling back to the original implementation if it had previously been set.