### PR TITLE
Buildscript compatibility

### DIFF
--- a/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
@@ -1,160 +1,171 @@
-﻿using System.IO;
-using System;
-using UnityEngine;
-using UnityEditor;
-using UnityEditor.Callbacks;
-using UnityEditor.iOS.Xcode;
-using UnityEditor.iOS.Xcode.Extensions;
-using System.Text;
+﻿#if UNITY_5_4_OR_NEWER && UNITY_IPHONE && UNITY_EDITOR
 
-/*
-   Adds required frameworks to the iOS project, and adds the OneSignalNotificationServiceExtension
-   Also handles making sure both targets (app and extension service) have the correct dependencies
-*/
+   using System.IO;
+   using System;
+   using UnityEngine;
+   using UnityEditor;
+   using UnityEditor.Callbacks;
+   using UnityEditor.iOS.Xcode;
+   using System.Text;
 
-#if UNITY_IPHONE && UNITY_EDITOR
+   #if UNITY_2017_1_OR_NEWER
+      using UnityEditor.iOS.Xcode.Extensions;
+   #endif
 
-public class BuildPostProcessor
-{
-   [PostProcessBuildAttribute(1)]
-   public static void OnPostProcessBuild(BuildTarget target, string path)
+   /*
+         Adds required frameworks to the iOS project, and adds the OneSignalNotificationServiceExtension
+         Also handles making sure both targets (app and extension service) have the correct dependencies
+      */
+
+   public class BuildPostProcessor
    {
-      string projectPath = PBXProject.GetPBXProjectPath(path);
-      PBXProject project = new PBXProject();
+      [PostProcessBuildAttribute(1)]
+      public static void OnPostProcessBuild(BuildTarget target, string path)
+      {
+         string projectPath = PBXProject.GetPBXProjectPath(path);
+         PBXProject project = new PBXProject();
 
-      project.ReadFromString(File.ReadAllText(projectPath));
-      string targetName = PBXProject.GetUnityTargetName();
-      string targetGUID = project.TargetGuidByName(targetName);
+         project.ReadFromString(File.ReadAllText(projectPath));
+         string targetName = PBXProject.GetUnityTargetName();
+         string targetGUID = project.TargetGuidByName(targetName);
 
-      // UserNotifications.framework is required by libOneSignal.a
-      project.AddFrameworkToProject(targetGUID, "UserNotifications.framework", false);
+         // UserNotifications.framework is required by libOneSignal.a
+         project.AddFrameworkToProject(targetGUID, "UserNotifications.framework", false);
 
-      var extensionTargetName = "OneSignalNotificationServiceExtension";
-      var pathToNotificationService = path + "/" + extensionTargetName;
+         #if UNITY_2017_1_OR_NEWER
 
-      Directory.CreateDirectory (pathToNotificationService);
+            var extensionTargetName = "OneSignalNotificationServiceExtension";
+            var pathToNotificationService = path + "/" + extensionTargetName;
 
-      var notificationServicePlistPath = pathToNotificationService + "/Info.plist";
+            Directory.CreateDirectory (pathToNotificationService);
 
-      PlistDocument notificationServicePlist = new PlistDocument();
-      notificationServicePlist.ReadFromFile ("Assets/OneSignal/Platforms/iOS/Info.plist");
-      notificationServicePlist.root.SetString ("CFBundleShortVersionString", PlayerSettings.bundleVersion);
-      notificationServicePlist.root.SetString ("CFBundleVersion", PlayerSettings.iOS.buildNumber.ToString ());
+            var notificationServicePlistPath = pathToNotificationService + "/Info.plist";
 
-      var notificationServiceTarget = PBXProjectExtensions.AddAppExtension (project, targetGUID, extensionTargetName, PlayerSettings.GetApplicationIdentifier (BuildTargetGroup.iOS) + "." + extensionTargetName, notificationServicePlistPath);
+            PlistDocument notificationServicePlist = new PlistDocument();
+            notificationServicePlist.ReadFromFile ("Assets/OneSignal/Platforms/iOS/Info.plist");
+            notificationServicePlist.root.SetString ("CFBundleShortVersionString", PlayerSettings.bundleVersion);
+            notificationServicePlist.root.SetString ("CFBundleVersion", PlayerSettings.iOS.buildNumber.ToString ());
 
-      var sourceDestination = extensionTargetName + "/NotificationService";
+            var notificationServiceTarget = PBXProjectExtensions.AddAppExtension (project, targetGUID, extensionTargetName, PlayerSettings.GetApplicationIdentifier (BuildTargetGroup.iOS) + "." + extensionTargetName, notificationServicePlistPath);
 
-      project.AddFileToBuild (notificationServiceTarget, project.AddFile (sourceDestination + ".h", sourceDestination + ".h", PBXSourceTree.Source));
-      project.AddFileToBuild (notificationServiceTarget, project.AddFile (sourceDestination + ".m", sourceDestination + ".m", PBXSourceTree.Source));
+            var sourceDestination = extensionTargetName + "/NotificationService";
 
-      var frameworks = new string[] {"NotificationCenter.framework", "UserNotifications.framework", "UIKit.framework", "SystemConfiguration.framework"};
+            project.AddFileToBuild (notificationServiceTarget, project.AddFile (sourceDestination + ".h", sourceDestination + ".h", PBXSourceTree.Source));
+            project.AddFileToBuild (notificationServiceTarget, project.AddFile (sourceDestination + ".m", sourceDestination + ".m", PBXSourceTree.Source));
 
-      foreach (string framework in frameworks) {
-         project.AddFrameworkToProject (notificationServiceTarget, framework, true);
+            var frameworks = new string[] {"NotificationCenter.framework", "UserNotifications.framework", "UIKit.framework", "SystemConfiguration.framework"};
+
+            foreach (string framework in frameworks) {
+               project.AddFrameworkToProject (notificationServiceTarget, framework, true);
+            }
+
+            //makes it so that the extension target is Universal (not just iPhone) and has an iOS 10 deployment target
+            project.SetBuildProperty(notificationServiceTarget, "TARGETED_DEVICE_FAMILY", "1,2");
+            project.SetBuildProperty(notificationServiceTarget, "IPHONEOS_DEPLOYMENT_TARGET", "10.0");
+
+            project.SetBuildProperty (notificationServiceTarget, "ARCHS", "$(ARCHS_STANDARD)");
+            project.SetBuildProperty (notificationServiceTarget, "DEVELOPMENT_TEAM", PlayerSettings.iOS.appleDeveloperTeamID);
+
+            notificationServicePlist.WriteToFile (notificationServicePlistPath);
+
+            FileUtil.CopyFileOrDirectory ("Assets/OneSignal/Platforms/iOS/NotificationService.h", path + "/" + sourceDestination + ".h");
+            FileUtil.CopyFileOrDirectory ("Assets/OneSignal/Platforms/iOS/NotificationService.m", path + "/" + sourceDestination + ".m");
+
+            project.WriteToFile (projectPath);
+
+            //add libOneSignal.a to the OneSignalNotificationServiceExtension target
+            string contents = File.ReadAllText(projectPath);
+
+            //this method only modifies the PBXProject string passed in (contents).
+            //after this method finishes, we must write the contents string to disk
+            InsertStaticFrameworkIntoTargetBuildPhaseFrameworks("libOneSignal", "CD84C25F20742FAB0035D524", notificationServiceTarget, ref contents, project);
+            File.WriteAllText(projectPath, contents);
+
+         #else 
+            project.WriteToFile (projectPath);
+
+            string contents = File.ReadAllText(projectPath);
+         #endif
+
+         // enable the Notifications capability in the main app target
+         project.ReadFromString(contents);
+         var entitlementPath = path + "/" + targetName + "/" + targetName + ".entitlements";
+
+         PlistDocument entitlements = new PlistDocument();
+         entitlements.root.SetString("aps-environment", "development");
+         entitlements.WriteToFile(entitlementPath);
+
+         // Copy the entitlement file to the xcode project
+         var entitlementFileName = Path.GetFileName(entitlementPath);
+         var unityTarget = PBXProject.GetUnityTargetName();
+         var relativeDestination = unityTarget + "/" + entitlementFileName;
+
+         // Add the pbx configs to include the entitlements files on the project
+         project.AddFile(relativeDestination, entitlementFileName);
+         project.AddBuildProperty(targetGUID, "CODE_SIGN_ENTITLEMENTS", relativeDestination);
+
+         // Add push notifications as a capability on the target
+         project.AddBuildProperty(targetGUID, "SystemCapabilities", "{com.apple.Push = {enabled = 1;};}");
+         File.WriteAllText(projectPath, project.WriteToString());
       }
 
-      //makes it so that the extension target is Universal (not just iPhone) and has an iOS 10 deployment target
-      project.SetBuildProperty(notificationServiceTarget, "TARGETED_DEVICE_FAMILY", "1,2");
-      project.SetBuildProperty(notificationServiceTarget, "IPHONEOS_DEPLOYMENT_TARGET", "10.0");
+      // This function takes a static framework that is already linked to a different target in the project and links it to the specified target
+      public static void InsertStaticFrameworkIntoTargetBuildPhaseFrameworks(string staticFrameworkName, string frameworkGuid, string target, ref string contents, PBXProject project) {
+         //in order to find the fileRef, find the PBXBuildFile objects section of the PBXProject
+         string splitString = " /* " + staticFrameworkName + ".a in Frameworks */ = {isa = PBXBuildFile; fileRef = ";
+         string[] splitComponents = contents.Split(new string[] {splitString}, StringSplitOptions.None);
 
-      project.SetBuildProperty (notificationServiceTarget, "ARCHS", "$(ARCHS_STANDARD)");
-      project.SetBuildProperty (notificationServiceTarget, "DEVELOPMENT_TEAM", PlayerSettings.iOS.appleDeveloperTeamID);
-
-      notificationServicePlist.WriteToFile (notificationServicePlistPath);
-
-      FileUtil.CopyFileOrDirectory ("Assets/OneSignal/Platforms/iOS/NotificationService.h", path + "/" + sourceDestination + ".h");
-      FileUtil.CopyFileOrDirectory ("Assets/OneSignal/Platforms/iOS/NotificationService.m", path + "/" + sourceDestination + ".m");
-
-      project.WriteToFile (projectPath);
-
-      //add libOneSignal.a to the OneSignalNotificationServiceExtension target
-      string contents = File.ReadAllText(projectPath);
-
-      //this method only modifies the PBXProject string passed in (contents).
-      //after this method finishes, we must write the contents string to disk
-      InsertStaticFrameworkIntoTargetBuildPhaseFrameworks("libOneSignal", "CD84C25F20742FAB0035D524", notificationServiceTarget, ref contents, project);
-      File.WriteAllText(projectPath, contents);
-
-      // enable the Notifications capability in the main app target
-      project.ReadFromString(contents);
-      var entitlementPath = path + "/" + targetName + "/" + targetName + ".entitlements";
-      
-      PlistDocument entitlements = new PlistDocument();
-      entitlements.root.SetString("aps-environment", "development");
-      entitlements.WriteToFile(entitlementPath);
-
-      // Copy the entitlement file to the xcode project
-      var entitlementFileName = Path.GetFileName(entitlementPath);
-      var unityTarget = PBXProject.GetUnityTargetName();
-      var relativeDestination = unityTarget + "/" + entitlementFileName;
-
-      // Add the pbx configs to include the entitlements files on the project
-      project.AddFile(relativeDestination, entitlementFileName);
-      project.AddBuildProperty(targetGUID, "CODE_SIGN_ENTITLEMENTS", relativeDestination);
-
-      // Add push notifications as a capability on the target
-      project.AddBuildProperty(targetGUID, "SystemCapabilities", "{com.apple.Push = {enabled = 1;};}");
-      File.WriteAllText(projectPath, project.WriteToString());
-   }
-
-   // This function takes a static framework that is already linked to a different target in the project and links it to the specified target
-   public static void InsertStaticFrameworkIntoTargetBuildPhaseFrameworks(string staticFrameworkName, string frameworkGuid, string target, ref string contents, PBXProject project) {
-      //in order to find the fileRef, find the PBXBuildFile objects section of the PBXProject
-      string splitString = " /* " + staticFrameworkName + ".a in Frameworks */ = {isa = PBXBuildFile; fileRef = ";
-      string[] splitComponents = contents.Split(new string[] {splitString}, StringSplitOptions.None);
-
-      if (splitComponents.Length < 2) {
-         Debug.LogError ("(error 1) OneSignal's Build Post Processor has encountered an error while attempting to add the Notification Extension Service to your project. Please create an issue on our OneSignal-Unity-SDK repo on GitHub.");
-         return;
-      }
-
-      string afterSplit = splitComponents[1];
-
-      //to get the fileRef of the static framework, read the last 24 characters of the beforeSplit string
-      StringBuilder fileRefBuilder = new StringBuilder();
-
-      for (int i = 0; i < 24; i++) {
-         fileRefBuilder.Append(afterSplit[i]);
-      }
-
-      string fileRef = fileRefBuilder.ToString();
-
-      project.AddFileToBuild(target, fileRef);
-
-      //add the framework as an additional object in PBXBuildFile objects
-      contents = contents.Replace("; fileRef = " + fileRef + " /* " + staticFrameworkName + ".a */; };", "; fileRef = " + fileRef + " /* " + staticFrameworkName + ".a */; };\n\t\t" + frameworkGuid + " /* " + staticFrameworkName + ".a in Frameworks */ = {isa = PBXBuildFile; fileRef = " + fileRef + " /* " + staticFrameworkName + ".a */; };");
-
-      //fild the build phase ID number
-      string targetBuildPhaseId = project.GetFrameworksBuildPhaseByTarget(target);
-      string[] components = contents.Split(new string[] { targetBuildPhaseId + " /* Frameworks */ = {\n\t\t\tisa = PBXFrameworksBuildPhase;\n\t\t\tbuildActionMask = " }, StringSplitOptions.None);
-
-      if (components.Length < 2) {
-         Debug.LogError("(error 2) OneSignal's Build Post Processor has encountered an error while attempting to add the Notification Extension Service to your project. Please create an issue on our OneSignal-Unity-SDK repo on GitHub.");
-         return;
-      }
-
-      string buildPhaseString = components[1];
-
-      StringBuilder replacer = new StringBuilder ();
-      
-      for (int i = 0; i < buildPhaseString.Length; i++) {
-         char seq = buildPhaseString [i];
-
-         if (char.IsNumber (seq)) {
-            replacer.Append (seq);
-         } else {
-            break;
+         if (splitComponents.Length < 2) {
+            Debug.LogError ("(error 1) OneSignal's Build Post Processor has encountered an error while attempting to add the Notification Extension Service to your project. Please create an issue on our OneSignal-Unity-SDK repo on GitHub.");
+            return;
          }
+
+         string afterSplit = splitComponents[1];
+
+         //to get the fileRef of the static framework, read the last 24 characters of the beforeSplit string
+         StringBuilder fileRefBuilder = new StringBuilder();
+
+         for (int i = 0; i < 24; i++) {
+            fileRefBuilder.Append(afterSplit[i]);
+         }
+
+         string fileRef = fileRefBuilder.ToString();
+
+         project.AddFileToBuild(target, fileRef);
+
+         //add the framework as an additional object in PBXBuildFile objects
+         contents = contents.Replace("; fileRef = " + fileRef + " /* " + staticFrameworkName + ".a */; };", "; fileRef = " + fileRef + " /* " + staticFrameworkName + ".a */; };\n\t\t" + frameworkGuid + " /* " + staticFrameworkName + ".a in Frameworks */ = {isa = PBXBuildFile; fileRef = " + fileRef + " /* " + staticFrameworkName + ".a */; };");
+
+         //fild the build phase ID number
+         string targetBuildPhaseId = project.GetFrameworksBuildPhaseByTarget(target);
+         string[] components = contents.Split(new string[] { targetBuildPhaseId + " /* Frameworks */ = {\n\t\t\tisa = PBXFrameworksBuildPhase;\n\t\t\tbuildActionMask = " }, StringSplitOptions.None);
+
+         if (components.Length < 2) {
+            Debug.LogError("(error 2) OneSignal's Build Post Processor has encountered an error while attempting to add the Notification Extension Service to your project. Please create an issue on our OneSignal-Unity-SDK repo on GitHub.");
+            return;
+         }
+
+         string buildPhaseString = components[1];
+
+         StringBuilder replacer = new StringBuilder ();
+
+         for (int i = 0; i < buildPhaseString.Length; i++) {
+            char seq = buildPhaseString [i];
+
+            if (char.IsNumber (seq)) {
+               replacer.Append (seq);
+            } else {
+               break;
+            }
+         }
+
+         // insert the framework into the PBXFrameworksBuildPhase 
+         string beginString = targetBuildPhaseId + " /* Frameworks */ = {\n\t\t\tisa = PBXFrameworksBuildPhase;\n\t\t\tbuildActionMask = " + replacer.ToString() + ";\n\t\t\tfiles = (";
+         contents = contents.Replace(beginString, beginString + "\n" + "\t\t\t\t" + frameworkGuid + " /* " + staticFrameworkName + ".a in Frameworks */,");
+
+         //add library search paths to add build configurations of the target
+         contents = contents.Replace ("PRODUCT_BUNDLE_IDENTIFIER = ", "LIBRARY_SEARCH_PATHS = (\n\t\t\t\t\t\"$(inherited)\",\n\t\t\t\t\t\"$(PROJECT_DIR)/Libraries/OneSignal/Platforms/iOS\",\n\t\t\t\t);\nPRODUCT_BUNDLE_IDENTIFIER = ");
       }
-
-      // insert the framework into the PBXFrameworksBuildPhase 
-      string beginString = targetBuildPhaseId + " /* Frameworks */ = {\n\t\t\tisa = PBXFrameworksBuildPhase;\n\t\t\tbuildActionMask = " + replacer.ToString() + ";\n\t\t\tfiles = (";
-      contents = contents.Replace(beginString, beginString + "\n" + "\t\t\t\t" + frameworkGuid + " /* " + staticFrameworkName + ".a in Frameworks */,");
-
-      //add library search paths to add build configurations of the target
-      contents = contents.Replace ("PRODUCT_BUNDLE_IDENTIFIER = ", "LIBRARY_SEARCH_PATHS = (\n\t\t\t\t\t\"$(inherited)\",\n\t\t\t\t\t\"$(PROJECT_DIR)/Libraries/OneSignal/Platforms/iOS\",\n\t\t\t\t);\nPRODUCT_BUNDLE_IDENTIFIER = ");
    }
-}
 
 #endif


### PR DESCRIPTION
• The build script that automatically injects required frameworks and adds the push notification service extension for iOS was using unity API's that were not supported in older versions of unity.
• Added compiler flag checks to ensure that the build script doesn't attempt to use API's that are not available in the developer's unity version.

resolves #114 