### PR TITLE
Duplicate fix buildscript

### DIFF
--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs
@@ -1,0 +1,101 @@
+/**
+ * Modified MIT License
+ * 
+ * Copyright 2018 OneSignal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * 1. The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * 2. All copies of substantial portions of the Software may only be used in connection
+ * with services provided by OneSignal.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Networking;
+using OneSignalPush.MiniJSON;
+using System.Collections.Generic;
+
+#if !UNITY_CLOUD_BUILD && UNITY_EDITOR 
+
+[InitializeOnLoad]
+public class OneSignalEditorCheckUpdateScript : AssetPostprocessor {
+   
+   //this key is used for the current unity session only
+   public static string sessionState = "onesignal_checked_update";
+   
+   //this key is saved between unity sessions and is essentially permanent
+   public static string sessionStatePersisted = "onesignal_checked_update_persisted";
+   
+   static OneSignalEditorCheckUpdateScript() {
+      Request();
+   }
+   
+   static void Request()
+   {
+      if (SessionState.GetBool(sessionState, false) == true) {
+         return;
+      }
+
+      SessionState.SetBool(sessionState, true);
+      
+      // issue a GET request to get the latest release
+      var url = "https://api.github.com/repos/OneSignal/OneSignal-Unity-SDK/releases/latest";
+      
+      var request = UnityWebRequest.Get(url);
+
+      request.SendWebRequest();
+
+      while (request.isDone == false) { }
+
+      if (request.isNetworkError || request.isHttpError)
+      {
+         Debug.LogError("OneSignal Update Checker Encountered an error: ");
+         Debug.LogError(request.error);
+      }
+      
+      //parse JSON to extract the latest version
+      var json = Json.Deserialize(request.downloadHandler.text) as Dictionary<string, object>;
+      
+      var latestVersionString = (json["tag_name"] as string);
+      var currentVersionString = File.ReadAllText("Assets/OneSignal/VERSION");
+
+      //remove . to convert "2.8.2" to "282" for example
+      var latestVersion = int.Parse(latestVersionString.Replace(".", ""));
+
+      var localVersion = int.Parse(currentVersionString.Replace(".", ""));
+
+      if (latestVersion > localVersion)
+      {
+         var updateMessage = "A new version of the OneSignal Unity SDK (" + latestVersionString + ") is available. You are currently using " + currentVersionString;
+         
+         if (EditorPrefs.GetBool(sessionStatePersisted + latestVersionString, false) == true) {
+            EditorPrefs.SetBool(sessionStatePersisted + latestVersionString, true);
+            //display an update message
+            Debug.LogWarning(updateMessage);
+         } else {
+            EditorUtility.DisplayDialog("OneSignal Update Available", updateMessage, "Ok");
+         }
+      }
+      
+   }
+   
+}
+
+#endif

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs
@@ -30,72 +30,101 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.Networking;
 using OneSignalPush.MiniJSON;
-using System.Collections.Generic;
+using System.Collections;
 
-#if !UNITY_CLOUD_BUILD && UNITY_EDITOR 
+#if !UNITY_CLOUD_BUILD && UNITY_EDITOR && UNITY_2017_1_OR_NEWER
 
 [InitializeOnLoad]
-public class OneSignalEditorCheckUpdateScript : AssetPostprocessor {
-   
+public class OneSignalEditorCheckUpdateScript : AssetPostprocessor
+{
    //this key is used for the current unity session only
    public static string sessionState = "onesignal_checked_update";
-   
-   //this key is saved between unity sessions and is essentially permanent
-   public static string sessionStatePersisted = "onesignal_checked_update_persisted";
-   
-   static OneSignalEditorCheckUpdateScript() {
+
+   static OneSignalUpdateRequest request;
+
+   static OneSignalEditorCheckUpdateScript()
+   {
       Request();
    }
-   
+
    static void Request()
    {
-      if (SessionState.GetBool(sessionState, false) == true) {
+      //if the SDK already checked for an update during this session, no need to do so again
+      if (SessionState.GetBool(sessionState, false)) {
          return;
       }
-
       SessionState.SetBool(sessionState, true);
-      
+
+      //because the update request is a MonoBehaviour object, must add as a component to a GameObject...
+      GameObject obj = new GameObject();
+
+      request = obj.AddComponent<OneSignalUpdateRequest>();
+
+      request.Start();
+   }
+}
+
+
+public class OneSignalUpdateRequest : MonoBehaviour
+{
+
+   //this key is saved between unity sessions and is essentially permanent
+   public static string sessionStatePersisted = "onesignal_checked_update_persisted";
+
+   private IEnumerator coroutine;
+
+   public void Start()
+   {
+      coroutine = FetchCurrentVersion("https://api.github.com/repos/OneSignal/OneSignal-Unity-SDK/releases/latest");
+
+      StartCoroutine(coroutine);
+   }
+
+   IEnumerator FetchCurrentVersion(string url)
+   {
       // issue a GET request to get the latest release
-      var url = "https://api.github.com/repos/OneSignal/OneSignal-Unity-SDK/releases/latest";
-      
       var request = UnityWebRequest.Get(url);
 
-      request.SendWebRequest();
+      yield return request.SendWebRequest();
+      
+      if (request.isNetworkError || request.isHttpError) {
+         if (request.error != null) {
+            Debug.LogError("OneSignal Update Checker encountered an unknown error");
+         } else {
+            Debug.LogError("OneSignal Update Checker encountered an error: " + request.error);
+         }
 
-      while (request.isDone == false) { }
-
-      if (request.isNetworkError || request.isHttpError)
-      {
-         Debug.LogError("OneSignal Update Checker Encountered an error: ");
-         Debug.LogError(request.error);
+         //since there was an error, we shouldn't attempt to serialize data from the request
+         yield break;
       }
-      
+
       //parse JSON to extract the latest version
-      var json = Json.Deserialize(request.downloadHandler.text) as Dictionary<string, object>;
-      
+      var json = Json.Deserialize(request.downloadHandler.text) as System.Collections.Generic.Dictionary<string, object>;
+
       var latestVersionString = (json["tag_name"] as string);
-      var currentVersionString = File.ReadAllText("Assets/OneSignal/VERSION");
+      var currentVersionString = File.ReadAllText("Assets/OneSignal/VERSION").Replace("\n", "");
 
       //remove . to convert "2.8.2" to "282" for example
       var latestVersion = int.Parse(latestVersionString.Replace(".", ""));
 
       var localVersion = int.Parse(currentVersionString.Replace(".", ""));
 
-      if (latestVersion > localVersion)
-      {
+      if (latestVersion > localVersion) {
          var updateMessage = "A new version of the OneSignal Unity SDK (" + latestVersionString + ") is available. You are currently using " + currentVersionString;
-         
-         if (EditorPrefs.GetBool(sessionStatePersisted + latestVersionString, false) == true) {
-            EditorPrefs.SetBool(sessionStatePersisted + latestVersionString, true);
-            //display an update message
-            Debug.LogWarning(updateMessage);
-         } else {
-            EditorUtility.DisplayDialog("OneSignal Update Available", updateMessage, "Ok");
+ 
+         Debug.LogWarning(updateMessage + "\nYou can download the new update from https://github.com/OneSignal/OneSignal-Unity-SDK/releases/latest\n");
+
+         // if the user has already seen an Update dialog for a new version, don't show it to them again for this version
+         if (!EditorPrefs.GetBool(sessionStatePersisted + latestVersionString, false)) {
+           //display an update message
+           EditorUtility.DisplayDialog("OneSignal Update Available", updateMessage + ". See the Console for a link to our latest release.", "Ok");
          }
+
+         EditorPrefs.SetBool(sessionStatePersisted + latestVersionString, true);
       }
-      
+
+      yield break;
    }
-   
 }
 
 #endif

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs.meta
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6b2cf8899230444f7ac5d9971406b4fd
+timeCreated: 1527895247
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
@@ -37,9 +37,13 @@
             var extensionTargetName = "OneSignalNotificationServiceExtension";
             var pathToNotificationService = path + "/" + extensionTargetName;
 
-            Directory.CreateDirectory (pathToNotificationService);
-
             var notificationServicePlistPath = pathToNotificationService + "/Info.plist";
+            
+            //if this is a rebuild, we've already added the extension service, no need to run this script a second time
+            if (File.Exists(notificationServicePlistPath)) 
+               return;
+      
+            Directory.CreateDirectory(pathToNotificationService);
 
             PlistDocument notificationServicePlist = new PlistDocument();
             notificationServicePlist.ReadFromFile ("Assets/OneSignal/Platforms/iOS/Info.plist");
@@ -67,9 +71,10 @@
             project.SetBuildProperty (notificationServiceTarget, "DEVELOPMENT_TEAM", PlayerSettings.iOS.appleDeveloperTeamID);
 
             notificationServicePlist.WriteToFile (notificationServicePlistPath);
-
-            FileUtil.CopyFileOrDirectory ("Assets/OneSignal/Platforms/iOS/NotificationService.h", path + "/" + sourceDestination + ".h");
-            FileUtil.CopyFileOrDirectory ("Assets/OneSignal/Platforms/iOS/NotificationService.m", path + "/" + sourceDestination + ".m");
+            
+            foreach (string type in new string[] {"m", "h"}) 
+               if (!File.Exists(path + "/" + sourceDestination + "." + type))
+                  FileUtil.CopyFileOrDirectory("Assets/OneSignal/Platforms/iOS/NotificationService.h", path + "/" + sourceDestination + "." + type);
 
             project.WriteToFile (projectPath);
 

--- a/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
@@ -32,7 +32,7 @@
          // UserNotifications.framework is required by libOneSignal.a
          project.AddFrameworkToProject(targetGUID, "UserNotifications.framework", false);
 
-         #if UNITY_2017_1_OR_NEWER
+         #if UNITY_2017_1_OR_NEWER && !UNITY_CLOUD_BUILD
 
             var extensionTargetName = "OneSignalNotificationServiceExtension";
             var pathToNotificationService = path + "/" + extensionTargetName;
@@ -109,7 +109,7 @@
          File.WriteAllText(projectPath, project.WriteToString());
       }
 
-      #if UNITY_2017_1_OR_NEWER
+      #if UNITY_2017_1_OR_NEWER && !UNITY_CLOUD_BUILD
          
          // This function takes a static framework that is already linked to a different target in the project and links it to the specified target
          public static void InsertStaticFrameworkIntoTargetBuildPhaseFrameworks(string staticFrameworkName, string frameworkGuid, string target, ref string contents, PBXProject project) {


### PR DESCRIPTION
• Fixes an issue that caused an error to be printed to the Unity console when the developer attempted to rebuild their project (instead of generating a new Xcode project)
• The build script attempted to copy a file (for the OneSignalNotificationServiceExtension) that would already have existed, causing an error.