### PR TITLE
Fix Rebuild Issue

### DIFF
--- a/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
@@ -40,9 +40,13 @@
             var extensionTargetName = "OneSignalNotificationServiceExtension";
             var pathToNotificationService = path + "/" + extensionTargetName;
 
-            Directory.CreateDirectory (pathToNotificationService);
-
             var notificationServicePlistPath = pathToNotificationService + "/Info.plist";
+      
+            //if this is a rebuild, we've already added the extension service, no need to run this script a second time
+            if (File.Exists(notificationServicePlistPath))
+               return;
+      
+            Directory.CreateDirectory(pathToNotificationService);
 
             PlistDocument notificationServicePlist = new PlistDocument();
             notificationServicePlist.ReadFromFile ("Assets/OneSignal/Platforms/iOS/Info.plist");
@@ -70,9 +74,10 @@
             project.SetBuildProperty (notificationServiceTarget, "DEVELOPMENT_TEAM", PlayerSettings.iOS.appleDeveloperTeamID);
 
             notificationServicePlist.WriteToFile (notificationServicePlistPath);
-
-            FileUtil.CopyFileOrDirectory ("Assets/OneSignal/Platforms/iOS/NotificationService.h", path + "/" + sourceDestination + ".h");
-            FileUtil.CopyFileOrDirectory ("Assets/OneSignal/Platforms/iOS/NotificationService.m", path + "/" + sourceDestination + ".m");
+      
+            foreach (string type in new string[] { "m", "h" })
+               if (!File.Exists(path + "/" + sourceDestination + "." + type))
+                  FileUtil.CopyFileOrDirectory("Assets/OneSignal/Platforms/iOS/NotificationService.h", path + "/" + sourceDestination + "." + type);
 
             project.WriteToFile (projectPath);
 


### PR DESCRIPTION
• Fixes an issue that caused an error to be printed to the Unity console when the developer attempted to rebuild their project (instead of generating a new Xcode project)
• The build script attempted to copy a file (for the OneSignalNotificationServiceExtension) that would already have existed, causing an error.