### PR TITLE
Buildscript extension fix

### DIFF
--- a/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
@@ -58,7 +58,7 @@
 
             var notificationServiceTarget = PBXProjectExtensions.AddAppExtension (project, targetGUID, extensionTargetName, PlayerSettings.GetApplicationIdentifier (BuildTargetGroup.iOS) + "." + extensionTargetName, notificationServicePlistPath);
 
-            var sourceDestination = extensionTargetName + separator + "NotificationService";
+            var sourceDestination = extensionTargetName + "/NotificationService";
 
             project.AddFileToBuild (notificationServiceTarget, project.AddFile (sourceDestination + ".h", sourceDestination + ".h", PBXSourceTree.Source));
             project.AddFileToBuild (notificationServiceTarget, project.AddFile (sourceDestination + ".m", sourceDestination + ".m", PBXSourceTree.Source));
@@ -115,7 +115,7 @@
          // Copy the entitlement file to the xcode project
          var entitlementFileName = Path.GetFileName(entitlementPath);
          var unityTarget = PBXProject.GetUnityTargetName();
-         var relativeDestination = unityTarget + separator + entitlementFileName;
+         var relativeDestination = unityTarget + "/" + entitlementFileName;
 
          // Add the pbx configs to include the entitlements files on the project
          project.AddFile(relativeDestination, entitlementFileName);

--- a/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
@@ -80,7 +80,7 @@
       
             foreach (string type in new string[] { "m", "h" })
                if (!File.Exists(path + separator + sourceDestination + "." + type))
-                  FileUtil.CopyFileOrDirectory(platformsLocation + "iOS" + separator + "NotificationService.h", path + separator + sourceDestination + "." + type);
+                  FileUtil.CopyFileOrDirectory(platformsLocation + "iOS" + separator + "NotificationService." + type, path + separator + sourceDestination + "." + type);
 
             project.WriteToFile (projectPath);
 

--- a/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/PostProcessBuildPlayer_iOS.cs
@@ -103,11 +103,19 @@
          var entitlementPath = path + separator + targetName + separator + targetName + ".entitlements";
 
          PlistDocument entitlements = new PlistDocument();
-         entitlements.root.SetString("aps-environment", "development");
+
+         if (File.Exists(entitlementPath))
+            entitlements.ReadFromFile(entitlementPath);
          
          #if !UNITY_CLOUD_BUILD && ADD_APP_GROUP
-            var groups = entitlements.root.CreateArray("com.apple.security.application-groups");
-            groups.AddString("group." + PlayerSettings.applicationIdentifier + ".onesignal");
+            if (entitlements.root["aps-environment"] == null) {
+               entitlements.root.SetString("aps-environment", "development");
+            }
+
+            if (entitlements.root["com.apple.security.application-groups"] == null) {
+               var groups = entitlements.root.CreateArray("com.apple.security.application-groups");
+               groups.AddString("group." + PlayerSettings.applicationIdentifier + ".onesignal");
+            }
          #endif
 
          entitlements.WriteToFile(entitlementPath);


### PR DESCRIPTION
• Fixes an issue where the iOS Unity buildscript was mistakenly copying a template header file from our assets directory into generated projects as both the header and implementation (.m) files. 
• Because interfaces are allowed to existing in Objective-C implementation files, this did not cause build errors or warnings, but would have resulted in no class implementation for the extension service class. This means rich push notifications would not have worked correctly
• Unfortunately we've never had tests in our unity SDK - we are considering adding a test suite in the future to catch such issues

• Fixes an issue where our iOS buildscript was using the correct directory separator character (`\` in windows, `/` in most other environments), but when generating the Xcode project, it was using the platform directory separator character instead of using the macOS `/`
• Fixed this by changing the macOS specific file paths to always use `/`

• Lastly, in rare situations some developers want to use a custom entitlements file. Our unity buildscript was overwriting existing entitlements files. 
• Fixes this issue by first reading in the contents of an existing entitlements file if it exists. It will only insert `aps-environment` and app group entitlements if they don't already exist.