### PR TITLE
Fix for play-services-resolver 1.2.88.0 w/ Android

### DIFF
--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalDependencies.xml
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalDependencies.xml
@@ -1,9 +1,9 @@
 <dependencies>
   <androidPackages>
-    <androidPackage spec="com.google.android.gms:play-services-base:[10.2.1, 12.1.0)" />
-    <androidPackage spec="com.google.firebase:firebase-messaging:[10.2.1, 12.1.0)"/>
-    <androidPackage spec="com.google.android.gms:play-services-location:[10.2.1, 12.1.0)" />
-    <androidPackage spec="com.android.support:support-v4:[26.0.0, 27.2.0)" />
-    <androidPackage spec="com.android.support:customtabs:[26.0.0, 27.2.0)" />
+    <androidPackage spec="com.google.android.gms:play-services-base:[10.2.1, 12.1.0[" />
+    <androidPackage spec="com.google.firebase:firebase-messaging:[10.2.1, 12.1.0["/>
+    <androidPackage spec="com.google.android.gms:play-services-location:[10.2.1, 12.1.0[" />
+    <androidPackage spec="com.android.support:support-v4:[26.0.0, 27.2.0[" />
+    <androidPackage spec="com.android.support:customtabs:[26.0.0, 27.2.0[" />
   </androidPackages>
 </dependencies>


### PR DESCRIPTION
* Changed version range dependencies to use '[' instead of '(' due to a bug with play-services-resolver 1.2.88.0+
* This relates to issue https://github.com/googlesamples/unity-jar-resolver/issues/151
* This resolves #146