### PR TITLE
Fixed error FileNotFoundException in OneSignalEditorScript_Android.cs

### DIFF
--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScript_Android.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScript_Android.cs
@@ -43,7 +43,7 @@ public class OneSignalEditorScriptAndroid : AssetPostprocessor {
    // Copies `AndroidManifestTemplate.xml` to `AndroidManifest.xml`
    //   then replace `${manifestApplicationId}` with current packagename in the Unity settings.
    private static void createOneSignalAndroidManifest() {
-      string oneSignalConfigPath = "Assets/Plugins/Android/OneSignalConfig/";
+      string oneSignalConfigPath = Application.dataPath + "/Plugins/Android/OneSignalConfig/";
       string manifestFullPath = oneSignalConfigPath + "AndroidManifest.xml";
 
       File.Copy(oneSignalConfigPath + "AndroidManifestTemplate.xml", manifestFullPath, true);


### PR DESCRIPTION
Hi there,

When I downloaded and install this SDK in my project, I got this error message.

![image](https://user-images.githubusercontent.com/2973238/79098550-36be4c80-7d9d-11ea-9537-95e9b9bc0bd7.png)

I don't know what is this use somewhere, that was wrong referencing path. (and `Assets/Plugins/OneSignalConfig/AndroidManifestTemplate.xml` is not in `.unitypackage`)
Please consider this PR.

Thanks :)