### PR TITLE
Added iOS IAM nil check to clickName

### DIFF
--- a/OneSignalExample/Assets/OneSignal/Platforms/iOS/OneSignalUnityRuntime.m
+++ b/OneSignalExample/Assets/OneSignal/Platforms/iOS/OneSignalUnityRuntime.m
@@ -167,7 +167,7 @@ void processInAppMessageClicked(char* inAppMessageActionString) {
 char* createInAppMessageJsonString(OSInAppMessageAction* action) {
     return os_cStringCopy(dictionaryToJsonChar(
     @{
-        @"click_name" : action.clickName,
+        @"click_name" : action.clickName ? action.clickName : @"",
         @"click_url" : action.clickUrl ? action.clickUrl.absoluteString : @"",
         @"first_click" : @(action.firstClick),
         @"closes_message" : @(action.closesMessage)


### PR DESCRIPTION
* This fixes the follow runtime iOS error when clicking on an IAM action
without an actionName set.
`Uncaught exception: NSInvalidArgumentException: *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]`

Fixes #292