### PR TITLE
Rename OneSignalConfig -> OneSignalConfig.plugin via an editor script - Fix up to PR #335

### DIFF
--- a/OneSignalExample/.gitignore
+++ b/OneSignalExample/.gitignore
@@ -61,4 +61,4 @@ Assets/Root
 
 /ProjectSettings/GoogleDependencyOneSignal.xml
 
-/Assets/Plugins/Android/OneSignalConfig/AndroidManifest.xml*
+**/OneSignalConfig.plugin/AndroidManifest.xml*

--- a/OneSignalExample/Assets/OneSignal/Editor/OSUnityEditorUtils.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OSUnityEditorUtils.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+
+using UnityEditor;
+using UnityEngine;
+
+internal class OSUnityEditorUtils {
+
+    // Searches for a list of file names accross the whole Unity project and provides
+    // the the GUID of the first found result.
+    internal static string FindFirstFileGUIDByName(String[] filenames) {
+        foreach (var filename in filenames) {
+            var pathGUIDs = AssetDatabase.FindAssets(filename);
+            if (pathGUIDs.Length > 0)
+                return pathGUIDs[0];
+        }
+        return null;
+    }
+
+    internal static void AppendFileExtensionIfMissing(string pathedFile, string extension) {
+        if (pathedFile == null) {
+            Debug.LogError($"AppendFileExtensionIfMissing: pathedFile can not be null");
+            return;
+        }
+
+        var pathParts = pathedFile.Split(Path.DirectorySeparatorChar);
+        var fileName = pathParts[pathParts.Length - 1];
+        if (!fileName.Contains("." + extension)) {
+            var result = AssetDatabase.MoveAsset(pathedFile, $"{pathedFile}.{extension}");
+            if (!String.IsNullOrEmpty(result))
+                Debug.LogError($"Could not add '.{extension}' to '{pathedFile}' due to error: {result}");
+        }
+    }
+}

--- a/OneSignalExample/Assets/OneSignal/Editor/OSUnityEditorUtils.cs.meta
+++ b/OneSignalExample/Assets/OneSignal/Editor/OSUnityEditorUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 29414a62dbb786840b657e43c9aa8260
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs
@@ -32,22 +32,14 @@ using UnityEngine.Networking;
 using OneSignalPush.MiniJSON;
 using System.Collections;
 
-#if !UNITY_CLOUD_BUILD && UNITY_EDITOR && UNITY_2017_1_OR_NEWER
-
-[InitializeOnLoad]
-public class OneSignalEditorCheckUpdateScript : AssetPostprocessor
+internal class OneSignalEditorCheckUpdateScript
 {
    //this key is used for the current unity session only
    public static string sessionState = "onesignal_checked_update";
 
    static OneSignalUpdateRequest request;
 
-   static OneSignalEditorCheckUpdateScript()
-   {
-      Request();
-   }
-
-   static void Request()
+   internal static void Request()
    {
       //if the SDK already checked for an update during this session, no need to do so again
       if (SessionState.GetBool(sessionState, false)) {
@@ -128,5 +120,3 @@ public class OneSignalUpdateRequest : MonoBehaviour
       yield break;
    }
 }
-
-#endif

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScriptInit.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScriptInit.cs
@@ -1,0 +1,13 @@
+#if UNITY_EDITOR
+using UnityEditor;
+
+[InitializeOnLoad]
+public class OneSignalEditorScriptInit : AssetPostprocessor {
+    static OneSignalEditorScriptInit() {
+        OneSignalFileStructureUpgrade.DoUpgrade();
+        #if UNITY_ANDROID
+        OneSignalEditorScriptAndroid.createOneSignalAndroidManifest();
+        #endif
+    }
+}
+#endif

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScriptInit.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScriptInit.cs
@@ -8,6 +8,9 @@ public class OneSignalEditorScriptInit : AssetPostprocessor {
         #if UNITY_ANDROID
         OneSignalEditorScriptAndroid.createOneSignalAndroidManifest();
         #endif
+        #if !UNITY_CLOUD_BUILD && UNITY_2017_1_OR_NEWER
+        OneSignalEditorCheckUpdateScript.Request();
+        #endif
     }
 }
 #endif

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScriptInit.cs.meta
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScriptInit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f90793c1a6cb9764d9685861fe9a21f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScript_Android.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScript_Android.cs
@@ -34,11 +34,11 @@ using UnityEditor;
 using System.Collections.Generic;
 
 internal class OneSignalEditorScriptAndroid {
-   
+
    // Copies `AndroidManifestTemplate.xml` to `AndroidManifest.xml`
    //   then replace `${manifestApplicationId}` with current packagename in the Unity settings.
    internal static void createOneSignalAndroidManifest() {
-      string oneSignalConfigPath = "Assets/Plugins/Android/OneSignalConfig.plugin/";
+      var oneSignalConfigPath = OneSignalFileLocator.GetOneSignalConfigFolderNameWithPath() + "/";
       string manifestFullPath = oneSignalConfigPath + "AndroidManifest.xml";
 
       File.Copy(oneSignalConfigPath + "AndroidManifestTemplate.xml", manifestFullPath, true);

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScript_Android.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScript_Android.cs
@@ -33,16 +33,11 @@ using UnityEditor;
 #if UNITY_ANDROID && UNITY_EDITOR
 using System.Collections.Generic;
 
-[InitializeOnLoad]
-public class OneSignalEditorScriptAndroid : AssetPostprocessor {
-
-   static OneSignalEditorScriptAndroid() {
-      createOneSignalAndroidManifest();
-   }
+internal class OneSignalEditorScriptAndroid {
    
    // Copies `AndroidManifestTemplate.xml` to `AndroidManifest.xml`
    //   then replace `${manifestApplicationId}` with current packagename in the Unity settings.
-   private static void createOneSignalAndroidManifest() {
+   internal static void createOneSignalAndroidManifest() {
       string oneSignalConfigPath = "Assets/Plugins/Android/OneSignalConfig.plugin/";
       string manifestFullPath = oneSignalConfigPath + "AndroidManifest.xml";
 

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalFileLocator.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalFileLocator.cs
@@ -1,0 +1,60 @@
+using System;
+
+using UnityEditor;
+using UnityEngine;
+
+internal class OneSignalFileLocator {
+
+    // Returns the full path of the OneSignalConfig folder.
+    // The folder contains a AndroidManifest.xml file which is required
+    // for Android push notifications to be received by the app.
+    internal static string GetOneSignalConfigFolderNameWithPath() {
+        var guid = GetOneSignalConfigGUID();
+        if (guid != null)
+            return AssetDatabase.GUIDToAssetPath(guid);
+
+        Debug.LogError($"OneSignal could not find required OneSignalConfig folder, push notifications will NOT display on Android!");
+        return null;
+    }
+
+    private static string GetOneSignalConfigGUID() {
+        // 1. Attempt to get GUID for folder
+        //    - This will be successful unless the Unity Dev deletes the matching .meta file or
+        //    moves the folder outside of Unity.
+        var guid = GetOneSignalConfigGUIDIfAvailable();
+        if (guid != null)
+            return guid;
+       
+        Debug.Log($"Didn't find '{FOLDER_NAME_V1_ONESIGNAL_CONFIG_NAME}' by GUID '{FOLDER_GUID_ONESIGNAL_CONFIG}', seaching by name.");
+    
+        // 2. Attempt by name if GUID look up fails
+        return GetOneSignalConfigGUIDByName();
+    }
+
+    // This is a static GUID defined in the OneSignalConfig.plugin.meta file in this repo.
+    private static readonly string FOLDER_GUID_ONESIGNAL_CONFIG = "4913d3bd89f197541850fb5382f2456d";
+    // Only provides GUID if it is found in project
+    private static string GetOneSignalConfigGUIDIfAvailable() {
+        var path = AssetDatabase.GUIDToAssetPath(FOLDER_GUID_ONESIGNAL_CONFIG);
+        if (!String.IsNullOrEmpty(path))
+            return FOLDER_GUID_ONESIGNAL_CONFIG;
+        return null;
+    }
+
+    private static readonly string FOLDER_NAME_V1_ONESIGNAL_CONFIG_NAME = "OneSignalConfig";
+    private static readonly string FOLDER_NAME_V2_ONESIGNAL_CONFIG_NAME = "OneSignalConfig.plugin";
+    private static readonly string[] FOLDER_NAME_ONESIGNAL_CONFIG_NAMES = new String[] {
+        FOLDER_NAME_V2_ONESIGNAL_CONFIG_NAME,
+        FOLDER_NAME_V1_ONESIGNAL_CONFIG_NAME
+    };
+    // Returns GUID of first found folder by name, null if not found.
+    private static string GetOneSignalConfigGUIDByName() {
+        var guid = OSUnityEditorUtils.FindFirstFileGUIDByName(FOLDER_NAME_ONESIGNAL_CONFIG_NAMES);
+        if (guid != null)
+            return guid;
+
+        var folderNames = String.Join(",", FOLDER_NAME_ONESIGNAL_CONFIG_NAMES);
+        Debug.LogError($"OneSignal - Could not find required Android folder from list of names; '{folderNames}'");
+        return null;
+    }
+}

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalFileLocator.cs.meta
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalFileLocator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6766942c90f8bcc47b74c6a99cf4099d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalFileStructureUpgrade.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalFileStructureUpgrade.cs
@@ -1,14 +1,10 @@
 #if UNITY_EDITOR
 
-using UnityEditor;
-using UnityEngine;
-
 // Add any files or folders that need to be rename, moved, or deleted in
 // as part of the process when updating this SDK.
-[InitializeOnLoad]
-public class OneSignalFileStructureUpgrade : AssetPostprocessor {
+internal class OneSignalFileStructureUpgrade {
 
-   static OneSignalFileStructureUpgrade() {
+   internal static void DoUpgrade() {
       UpgradeToSDKVersion2_13_3();
    }
 

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalFileStructureUpgrade.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalFileStructureUpgrade.cs
@@ -1,0 +1,31 @@
+#if UNITY_EDITOR
+
+using UnityEditor;
+using UnityEngine;
+
+// Add any files or folders that need to be rename, moved, or deleted in
+// as part of the process when updating this SDK.
+[InitializeOnLoad]
+public class OneSignalFileStructureUpgrade : AssetPostprocessor {
+
+   static OneSignalFileStructureUpgrade() {
+      UpgradeToSDKVersion2_13_3();
+   }
+
+   private static void UpgradeToSDKVersion2_13_3() {
+      #if UNITY_ANDROID
+      RenameAndroidOneSignalConfig();
+      #endif
+   }
+
+   // This renames the folder "OneSignalConfig" to "OneSignal.plugin".
+   // ".plugin" is Unity documented folder post-fix required for some plugins features.
+   //    - This is required to fix Unity 2020+ capability.
+   // This is done via a script since .unitypackage files do not support renaming
+   // and so this is required for those upgrading from an older version of the SDK.
+   private static void RenameAndroidOneSignalConfig() {
+      var path = OneSignalFileLocator.GetOneSignalConfigFolderNameWithPath();
+      OSUnityEditorUtils.AppendFileExtensionIfMissing(path, "plugin");
+   }
+}
+#endif

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalFileStructureUpgrade.cs.meta
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalFileStructureUpgrade.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bbb98b31f3ecb1a408f335958346294b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/buildpackage.sh
+++ b/buildpackage.sh
@@ -17,7 +17,7 @@ temp_location=$(pwd)/onesignal_temp
 icons_location=$project_path/Assets/AppIcons
 icons_temp_location=$(pwd)/onesignal_temp/tempAppIcons
 android_location=$project_path/Assets/Plugins/Android
-config_location=$android_location/OneSignalConfig
+config_location=$android_location/OneSignalConfig.plugin
 package_manifest=$project_path/Packages/manifest.json
 temp_package_manifest=$temp_location/Packages/manifest.json
 
@@ -40,16 +40,16 @@ mv $icons_location.meta $icons_temp_location.meta
 # This removes any .aar files we don't want to bundle in our package
 
 # temporarily move some necessary files
-mv $config_location $temp_location/OneSignalConfig
-mv $config_location.meta $temp_location/OneSignalConfig.meta
+mv $config_location $temp_location/OneSignalConfig.plugin
+mv $config_location.meta $temp_location/OneSignalConfig.plugin.meta
 
 # get rid of a bunch of unnecessary files
 rm -r $android_location
 mkdir $android_location
 
 # put the config files back
-mv $temp_location/OneSignalConfig $config_location
-mv $temp_location/OneSignalConfig.meta $config_location.meta
+mv $temp_location/OneSignalConfig.plugin $config_location
+mv $temp_location/OneSignalConfig.plugin.meta $config_location.meta
 
 ## END - Clean Android files
 


### PR DESCRIPTION
## Scope
## Issue
When someone updates to the latest SDK by importing it's `.unitypackage` file the `OneSignalConfig` folder does not get renamed to `OneSignalConfig.plugin` required for the fix in PR #335 to work.

### Fix
Solution B noted below is implemented in this PR.

### Solutions
#### A. Change the .meta GUID
I attempt to first change the GUID in the `OneSignalConfig.plugin.meta` file, hoping Unity would think this is new and move all it's child files. It ignores it as I assume this is due the fact that the `.meta` of all the child files did not change. If we give all new GUIDs to these files than it would result in having a `OneSignalConfig.plugin` folder with all files we want it however "OneSignalConfig" would stick around. These duplicate files would create build issues so this won't work.

#### B. Create custom Unity Editor Scripts to rename folder
This seems pretty feasible after discovering the [`AssetDatabase`](https://docs.unity3d.com/2020.1/Documentation/ScriptReference/AssetDatabase.html) API provided by Unity. It has `MoveAsset` which is exactly what we want. To make this more robust incase a Unity Dev moves the OneSignal folder to a different local I also used the `AssetPathToGUID` and `FindAssets` API.

### Map of code added
* [`OneSignalFileStructureUpgrade`](https://github.com/OneSignal/OneSignal-Unity-SDK/pull/336/files#diff-2b03e381b6527f9e7d65f74ef51ad52380241195fa5c5be49ee0fdb1fd977ac6)- This is where we define specific
   file moves / renames or deletes in the future if needed.
* [`OneSignalFileLocator `](https://github.com/OneSignal/OneSignal-Unity-SDK/pull/336/files#diff-53f52b40810747d6ce433c5867dc6abc55a249698ac066c5f0ab0f8d233ac492)- This does a safe look up with GUID first
   but falls back to file name searches in case the Unity Dev moves
   files around.
* [`OSUnityEditorUtils`](https://github.com/OneSignal/OneSignal-Unity-SDK/pull/336/files#diff-7ed974ba0a15e4ac72c88f9e3cd3b15aab8259cbee1ef602a7fe2ba06504b937) - These are helpers to keep the other two classes
   as clean as possible away from specific Unity implementation details.
* [`OneSignalEditorScriptInit`](https://github.com/OneSignal/OneSignal-Unity-SDK/pull/336/files#diff-83606d2a29555f577f5dca686ad318d61c8892c41d12e14345c411a166b33755) - Entry point to define a execution order for all OneSignal editor scripts.

### Related misc fixes
* `OneSignalConfig.plugin` references updated in `buildpackage.sh` missed in PR #335.
* `OneSignalConfig.plugin` reference in `.gitignore` missed in PR #335

## Testing
### Manual
Tested on Windows 10 with Unity 2020.2.2f1.
* Renamed "OneSignalConfig.plugin" back to  "OneSignalConfig", confirmed rename happened when:
   - Switched platforms back to Android
   - Restarting Unity
* Ensure rename still works if folder is named "OneSignalConfig" but it's GUID is different.