### PR TITLE
Code Quality - Align rest of code base to use OneSignalEditorScriptInit & OneSignalFileLocator added in PR #336

### DIFF
--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs
@@ -32,22 +32,14 @@ using UnityEngine.Networking;
 using OneSignalPush.MiniJSON;
 using System.Collections;
 
-#if !UNITY_CLOUD_BUILD && UNITY_EDITOR && UNITY_2017_1_OR_NEWER
-
-[InitializeOnLoad]
-public class OneSignalEditorCheckUpdateScript : AssetPostprocessor
+internal class OneSignalEditorCheckUpdateScript
 {
    //this key is used for the current unity session only
    public static string sessionState = "onesignal_checked_update";
 
    static OneSignalUpdateRequest request;
 
-   static OneSignalEditorCheckUpdateScript()
-   {
-      Request();
-   }
-
-   static void Request()
+   internal static void Request()
    {
       //if the SDK already checked for an update during this session, no need to do so again
       if (SessionState.GetBool(sessionState, false)) {
@@ -128,5 +120,3 @@ public class OneSignalUpdateRequest : MonoBehaviour
       yield break;
    }
 }
-
-#endif

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScriptInit.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScriptInit.cs
@@ -8,6 +8,9 @@ public class OneSignalEditorScriptInit : AssetPostprocessor {
         #if UNITY_ANDROID
         OneSignalEditorScriptAndroid.createOneSignalAndroidManifest();
         #endif
+        #if !UNITY_CLOUD_BUILD && UNITY_2017_1_OR_NEWER
+        OneSignalEditorCheckUpdateScript.Request();
+        #endif
     }
 }
 #endif

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScript_Android.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorScript_Android.cs
@@ -34,11 +34,11 @@ using UnityEditor;
 using System.Collections.Generic;
 
 internal class OneSignalEditorScriptAndroid {
-   
+
    // Copies `AndroidManifestTemplate.xml` to `AndroidManifest.xml`
    //   then replace `${manifestApplicationId}` with current packagename in the Unity settings.
    internal static void createOneSignalAndroidManifest() {
-      string oneSignalConfigPath = "Assets/Plugins/Android/OneSignalConfig.plugin/";
+      var oneSignalConfigPath = OneSignalFileLocator.GetOneSignalConfigFolderNameWithPath() + "/";
       string manifestFullPath = oneSignalConfigPath + "AndroidManifest.xml";
 
       File.Copy(oneSignalConfigPath + "AndroidManifestTemplate.xml", manifestFullPath, true);


### PR DESCRIPTION
## Scope
Incorporate some of the structure(`OneSignalEditorScriptInit`) and helpers(`OneSignalFileLocator`) introduced in PR #336 to the rest of the code base to improve code quality.

## Testing
### Manual
Tested on Windows 10 with Unity 2020.2.2f1.
* Ensured `AndroidManifest.xml` is correctly generated from `AndroidManifestTemplate.xml`.