### PR TITLE
Remove Android minSdkVersion to fix build error due to lint problem

### DIFF
--- a/OneSignalExample/Assets/Plugins/Android/OneSignalConfig.plugin/AndroidManifestTemplate.xml
+++ b/OneSignalExample/Assets/Plugins/Android/OneSignalConfig.plugin/AndroidManifestTemplate.xml
@@ -7,9 +7,7 @@
     package="com.onesignal.onesignalsdk"
     android:versionCode="1"
     android:versionName="1.0" >
-    
-    <uses-sdk android:minSdkVersion="15" />
-    
+
     <permission android:name="${manifestApplicationId}.permission.C2D_MESSAGE" android:protectionLevel="signature" />
     <uses-permission android:name="${manifestApplicationId}.permission.C2D_MESSAGE" />
     <application>


### PR DESCRIPTION
* Defining `minSdkVersion` in the `AndroidManifest.xml` is a lint error with Android Gradle builds so this was removed.
    - This used to be required for much other version of Unity not using Gradle to build. As with ANT it would default to 1 which would create other build issues.
* This fixes Android build errors on new Unity 2020.2 projects.
* Tested this is not needed any longer back to Unity 2018.4.31 as well
* Fixes #281

