### PR TITLE
Clean up update checker Unity 2020 editor warnings

### DIFF
--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs
@@ -79,7 +79,11 @@ public class OneSignalUpdateRequest : MonoBehaviour
 
       yield return request.SendWebRequest();
       
-      if (request.isNetworkError || request.isHttpError) {
+      var requestError =
+         request.result == UnityWebRequest.Result.ProtocolError ||
+         request.result == UnityWebRequest.Result.ConnectionError;
+      
+      if (requestError) {
          if (request.error != null) {
             Debug.LogError("OneSignal Update Checker encountered an unknown error");
          } else {

--- a/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/OneSignalEditorCheckUpdateScript.cs
@@ -78,11 +78,17 @@ public class OneSignalUpdateRequest : MonoBehaviour
       var request = UnityWebRequest.Get(url);
 
       yield return request.SendWebRequest();
-      
-      var requestError =
-         request.result == UnityWebRequest.Result.ProtocolError ||
-         request.result == UnityWebRequest.Result.ConnectionError;
-      
+
+      #if UNITY_2020_1_OR_NEWER
+         var requestError =
+            request.result == UnityWebRequest.Result.ProtocolError ||
+            request.result == UnityWebRequest.Result.ConnectionError;
+      #else
+         var requestError =
+            request.isNetworkError ||
+            request.isHttpError;
+      #endif
+
       if (requestError) {
          if (request.error != null) {
             Debug.LogError("OneSignal Update Checker encountered an unknown error");


### PR DESCRIPTION
* Cleans up `UnityWebRequest` warnings in Unity 2020.1 and newer.

![Screenshot 2021-03-05 085341](https://user-images.githubusercontent.com/645861/110150479-2c7db600-7d94-11eb-9eff-8a71b99612aa.png)

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/345)
<!-- Reviewable:end -->

