### PR TITLE
Extra layer of safety for custom build pipelines

### DIFF
--- a/com.onesignal.unity.ios/Editor/PostProcessBuildPlayer_iOS.cs
+++ b/com.onesignal.unity.ios/Editor/PostProcessBuildPlayer_iOS.cs
@@ -115,6 +115,8 @@ public static class BuildPostProcessor
     [PostProcessBuildAttribute(1)]
     public static void OnPostProcessBuild(BuildTarget target, string path)
     {
+        if (target != BuildTarget.iOS) return;
+    
         var projectPath = PBXProject.GetPBXProjectPath(path);
         var project = new PBXProject();
 


### PR DESCRIPTION
Enforce build targets when using PostProcessBuild. This avoids problems in the editor related to custom build pipelines (i.e., bypassing Unity's auto-switch to a particular editor build environment), which bypasses your ```#if UNITY_IPHONE``` directive, and leads a DirectoryNotFound exception, like this: https://pastebin.com/T8UEGcH6

That exception was generated when building for Android, which interrupted/faulted the build.

A simple one-liner prevents this from ever happening. I've seen this approach used before and use it myself: It appears to be fairly common practice. Here's an example of a Unity developer enforcing the correct build target: https://forum.unity.com/threads/how-can-you-add-items-to-the-xcode-project-targets-info-plist-using-the-xcodeapi.330574/#post-2143867

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/371)
<!-- Reviewable:end -->
