### PR TITLE
Fix critical build error

### DIFF
--- a/com.onesignal.unity.ios/Editor/PostProcessBuildPlayer_iOS.cs
+++ b/com.onesignal.unity.ios/Editor/PostProcessBuildPlayer_iOS.cs
@@ -252,7 +252,7 @@ public static class BuildPostProcessor
         project.SetBuildProperty(extensionGUID, "DEVELOPMENT_TEAM", PlayerSettings.iOS.appleDeveloperTeamID);
 
         project.AddBuildProperty(extensionGUID, "LIBRARY_SEARCH_PATHS", 
-            $"$(PROJECT_DIR)/Libraries/{PluginLibrariesPath}");
+            $"$(PROJECT_DIR)/Libraries/{PluginLibrariesPath.Replace("\\", "/")}");
         project.WriteToFile(projectPath);
 
         // Add libOneSignal.a to the OneSignalNotificationServiceExtension target

--- a/com.onesignal.unity.ios/Editor/PostProcessBuildPlayer_iOS.cs
+++ b/com.onesignal.unity.ios/Editor/PostProcessBuildPlayer_iOS.cs
@@ -287,6 +287,8 @@ public static class BuildPostProcessor
             
             var destPathRelative = Path.Combine(NotificationServiceExtensionTargetName, fileName);
             var destPath = Path.Combine(projectPath, destPathRelative);
+            destPath = destPath.Replace("\\","/");
+            sourcePath = sourcePath.Replace("\\","/");
             if (!File.Exists(destPath))
                 FileUtil.CopyFileOrDirectory(sourcePath, destPath);
             

--- a/com.onesignal.unity.ios/Editor/PostProcessBuildPlayer_iOS.cs
+++ b/com.onesignal.unity.ios/Editor/PostProcessBuildPlayer_iOS.cs
@@ -287,10 +287,8 @@ public static class BuildPostProcessor
             
             var destPathRelative = Path.Combine(NotificationServiceExtensionTargetName, fileName);
             var destPath = Path.Combine(projectPath, destPathRelative);
-            destPath = destPath.Replace("\\","/");
-            sourcePath = sourcePath.Replace("\\","/");
             if (!File.Exists(destPath))
-                FileUtil.CopyFileOrDirectory(sourcePath, destPath);
+                FileUtil.CopyFileOrDirectory(sourcePath.Replace("\\", "/"), destPath.Replace("\\", "/"));
             
             var sourceFileGUID = project.AddFile(destPathRelative, destPathRelative);
             project.AddFileToBuildSection(extensionGUID, buildPhaseID, sourceFileGUID);


### PR DESCRIPTION
Re: https://github.com/OneSignal/OneSignal-Unity-SDK/issues/375

FileUtil.CopyFileORDirectory documentation explicitly requires all pathing to use forward slashes: https://docs.unity3d.com/ScriptReference/FileUtil.CopyFileOrDirectory.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/376)
<!-- Reviewable:end -->
