### PR TITLE
[Fix] Missing getters for subscription states and push permissions

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Added in missing getters for the permission and subscription states
+### Changed
+- `PermissionState` has been removed and the `NotficationPermission` enum is reported in its place.
+  - Associated event `PermissionStateChanged` has been renamed to `NotificationPermissionChanged`
 
 ## [3.0.0-beta.2]
 ### Fixed

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -6,10 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Added in missing getters for the permission and subscription states
+- Add missing getters for permission and subscription states
 ### Changed
-- `PermissionState` has been removed and the `NotficationPermission` enum is reported in its place.
-  - Associated event `PermissionStateChanged` has been renamed to `NotificationPermissionChanged`
+- Removed `PermissionState` in favor of `NotificationPermission` enum
+  - Renamed `PermissionStateChanged` event to `NotificationPermissionChanged`
 
 ## [3.0.0-beta.2]
 ### Fixed

--- a/OneSignalExample/Assets/OneSignal/Example/OneSignalExampleBehaviour.cs
+++ b/OneSignalExample/Assets/OneSignal/Example/OneSignalExampleBehaviour.cs
@@ -93,7 +93,7 @@ namespace OneSignalSDK {
             OneSignal.Default.InAppMessageTriggeredAction += _iamTriggeredAction;
             
             // Setup the below to listen for and respond to state changes
-            OneSignal.Default.PermissionStateChanged        += _permissionStateChanged;
+            OneSignal.Default.NotificationPermissionChanged += _notificationPermissionChanged;
             OneSignal.Default.PushSubscriptionStateChanged  += _pushStateChanged;
             OneSignal.Default.EmailSubscriptionStateChanged += _emailStateChanged;
             OneSignal.Default.SMSSubscriptionStateChanged   += _smsStateChanged;
@@ -133,8 +133,8 @@ namespace OneSignalSDK {
             _log($"IAM triggered action: {JsonUtility.ToJson(inAppMessageAction)}");
         }
 
-        private void _permissionStateChanged(PermissionState current, PermissionState previous) {
-            _log($"Permission state changed to: {JsonUtility.ToJson(current)}");
+        private void _notificationPermissionChanged(NotificationPermission current, NotificationPermission previous) {
+            _log($"Notification Permissions changed to: {current}");
         }
 
         private void _pushStateChanged(PushSubscriptionState current, PushSubscriptionState previous) {

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.Callbacks.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.Callbacks.cs
@@ -98,8 +98,12 @@ namespace OneSignalSDK {
 
             /// <param name="stateChanges">OSPermissionStateChanges</param>
             public void onOSPermissionChanged(AndroidJavaObject stateChanges) {
-                var (curr, prev) = _getStatesChanges<PermissionState>(stateChanges);
-                _instance.PermissionStateChanged?.Invoke(curr, prev);
+                var currJO  = stateChanges.Call<AndroidJavaObject>("getTo");
+                var prevJO  = stateChanges.Call<AndroidJavaObject>("getFrom");
+                var curr = _stateNotificationPermission(currJO);
+                var prev = _stateNotificationPermission(prevJO);
+                
+                _instance.NotificationPermissionChanged?.Invoke(curr, prev);
             }
         }
 

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.Mappings.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.Mappings.cs
@@ -48,5 +48,10 @@ namespace OneSignalSDK {
             var msg  = error.Call<string>("getMessage");
             SDKDebug.Error($"{type} - {msg}");
         }
+
+        private static NotificationPermission _stateNotificationPermission(AndroidJavaObject stateWithPermissions) {
+            var enabled = stateWithPermissions.Call<bool>("areNotificationsEnabled");
+            return enabled ? NotificationPermission.Authorized : NotificationPermission.Denied;
+        }
     }
 }

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
@@ -44,6 +44,40 @@ namespace OneSignalSDK {
         public override event StateChangeDelegate<PushSubscriptionState> PushSubscriptionStateChanged;
         public override event StateChangeDelegate<EmailSubscriptionState> EmailSubscriptionStateChanged;
         public override event StateChangeDelegate<SMSSubscriptionState> SMSSubscriptionStateChanged;
+        
+        public override PushSubscriptionState PushSubscriptionState {
+            get {
+                var deviceStateJO = _sdkClass.CallStatic<AndroidJavaObject>("getDeviceState");
+                return new PushSubscriptionState {
+                    userId         = deviceStateJO.Call<string>("getUserId"),
+                    pushToken      = deviceStateJO.Call<string>("getPushToken"),
+                    isSubscribed   = deviceStateJO.Call<bool>("isSubscribed"),
+                    isPushDisabled = deviceStateJO.Call<bool>("isPushDisabled"),
+                };
+            }
+        }
+        
+        public override EmailSubscriptionState EmailSubscriptionState {
+            get {
+                var deviceStateJO = _sdkClass.CallStatic<AndroidJavaObject>("getDeviceState");
+                return new EmailSubscriptionState {
+                    emailUserId  = deviceStateJO.Call<string>("getEmailUserId"),
+                    emailAddress = deviceStateJO.Call<string>("getEmailAddress"),
+                    isSubscribed = deviceStateJO.Call<bool>("isEmailSubscribed"),
+                };
+            }
+        }
+        
+        public override SMSSubscriptionState SMSSubscriptionState {
+            get {
+                var deviceStateJO = _sdkClass.CallStatic<AndroidJavaObject>("getDeviceState");
+                return new SMSSubscriptionState {
+                    smsUserId    = deviceStateJO.Call<string>("getSMSUserId"),
+                    smsNumber    = deviceStateJO.Call<string>("getSMSNumber"),
+                    isSubscribed = deviceStateJO.Call<bool>("isSMSSubscribed"),
+                };
+            }
+        }
 
         public override bool PrivacyConsent {
             get => _sdkClass.CallStatic<bool>("userProvidedPrivacyConsent");

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
@@ -27,7 +27,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -40,11 +39,14 @@ namespace OneSignalSDK {
         public override event InAppMessageLifecycleDelegate InAppMessageWillDismiss;
         public override event InAppMessageLifecycleDelegate InAppMessageDidDismiss;
         public override event InAppMessageActionDelegate InAppMessageTriggeredAction;
-        public override event StateChangeDelegate<PermissionState> PermissionStateChanged;
+        public override event StateChangeDelegate<NotificationPermission> NotificationPermissionChanged;
         public override event StateChangeDelegate<PushSubscriptionState> PushSubscriptionStateChanged;
         public override event StateChangeDelegate<EmailSubscriptionState> EmailSubscriptionStateChanged;
         public override event StateChangeDelegate<SMSSubscriptionState> SMSSubscriptionStateChanged;
-        
+
+        public override NotificationPermission NotificationPermission
+            => _stateNotificationPermission(_sdkClass.CallStatic<AndroidJavaObject>("getDeviceState"));
+
         public override PushSubscriptionState PushSubscriptionState {
             get {
                 var deviceStateJO = _sdkClass.CallStatic<AndroidJavaObject>("getDeviceState");

--- a/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
+++ b/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
@@ -48,6 +48,11 @@ namespace OneSignalSDK {
 
         public override bool PrivacyConsent { get; set; }
         public override bool RequiresPrivacyConsent { get; set; }
+        
+        public override PermissionState PermissionState { get; }
+        public override PushSubscriptionState PushSubscriptionState { get; }
+        public override EmailSubscriptionState EmailSubscriptionState { get; }
+        public override SMSSubscriptionState SMSSubscriptionState { get; }
 
         public override void Initialize(string appId) {
             if (string.IsNullOrEmpty(appId)) {

--- a/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
+++ b/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
@@ -41,7 +41,7 @@ namespace OneSignalSDK {
         public override event InAppMessageLifecycleDelegate InAppMessageWillDismiss;
         public override event InAppMessageLifecycleDelegate InAppMessageDidDismiss;
         public override event InAppMessageActionDelegate InAppMessageTriggeredAction;
-        public override event StateChangeDelegate<PermissionState> PermissionStateChanged;
+        public override event StateChangeDelegate<NotificationPermission> NotificationPermissionChanged;
         public override event StateChangeDelegate<PushSubscriptionState> PushSubscriptionStateChanged;
         public override event StateChangeDelegate<EmailSubscriptionState> EmailSubscriptionStateChanged;
         public override event StateChangeDelegate<SMSSubscriptionState> SMSSubscriptionStateChanged;
@@ -49,7 +49,7 @@ namespace OneSignalSDK {
         public override bool PrivacyConsent { get; set; }
         public override bool RequiresPrivacyConsent { get; set; }
         
-        public override PermissionState PermissionState { get; }
+        public override NotificationPermission NotificationPermission { get; }
         public override PushSubscriptionState PushSubscriptionState { get; }
         public override EmailSubscriptionState EmailSubscriptionState { get; }
         public override SMSSubscriptionState SMSSubscriptionState { get; }

--- a/com.onesignal.unity.core/Runtime/Models/NotificationPermission.cs
+++ b/com.onesignal.unity.core/Runtime/Models/NotificationPermission.cs
@@ -25,15 +25,13 @@
  * THE SOFTWARE.
  */
 
-using System;
-
 namespace OneSignalSDK {
     /// <summary>
-    /// Status of ability to send push notification as determined by the current user
+    /// Status of ability to send push notifications to the current device as determined by its user
     /// </summary>
     public enum NotificationPermission {
         /// <summary>The user has not yet made a choice regarding whether your app can show notifications.</summary>
-        NotDetermined,
+        NotDetermined = 0,
 
         /// <summary>The application is not authorized to post user notifications.</summary>
         Denied,
@@ -46,23 +44,5 @@ namespace OneSignalSDK {
 
         /// <summary>The application is authorized to send notifications for 8 hours. Only used by App Clips.</summary>
         Ephemeral
-    }
-
-    [Serializable] public sealed class PermissionState {
-        /// <summary>
-        /// Whether or not the user has been asked for permission to receive push notifications. See
-        /// <see cref="OneSignal.PromptForPushNotificationsWithUserResponse"/> to acquire permission
-        /// </summary>
-        public bool hasPrompted;
-
-        /// <summary>
-        /// Status of ability to send push notification as determined by the current user
-        /// </summary>
-        public NotificationPermission status;
-        
-        /// <summary>
-        /// 
-        /// </summary>
-        public bool provisional;
     }
 }

--- a/com.onesignal.unity.core/Runtime/Models/NotificationPermission.cs.meta
+++ b/com.onesignal.unity.core/Runtime/Models/NotificationPermission.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: fd1510c507f2f0b45a93abc79088eaa9
+guid: 545ae9e8a8e3e4d6192727d2b4b2107e
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/com.onesignal.unity.core/Runtime/Models/PermissionState.cs
+++ b/com.onesignal.unity.core/Runtime/Models/PermissionState.cs
@@ -40,17 +40,29 @@ namespace OneSignalSDK {
 
         /// <summary>The application is authorized to post user notifications.</summary>
         Authorized,
-        
+
         /// <summary>The application is only authorized to post Provisional notifications (direct to history)</summary>
         Provisional,
-        
+
         /// <summary>The application is authorized to send notifications for 8 hours. Only used by App Clips.</summary>
         Ephemeral
     }
 
     [Serializable] public sealed class PermissionState {
+        /// <summary>
+        /// Whether or not the user has been asked for permission to receive push notifications. See
+        /// <see cref="OneSignal.PromptForPushNotificationsWithUserResponse"/> to acquire permission
+        /// </summary>
         public bool hasPrompted;
+
+        /// <summary>
+        /// Status of ability to send push notification as determined by the current user
+        /// </summary>
         public NotificationPermission status;
+        
+        /// <summary>
+        /// 
+        /// </summary>
         public bool provisional;
     }
 }

--- a/com.onesignal.unity.core/Runtime/OneSignal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.cs
@@ -285,7 +285,7 @@ namespace OneSignalSDK {
         public abstract Task<bool> DeleteTags(params string[] keys);
     #endregion
 
-    #region User Identification
+    #region User & Device Properties
         /// <summary>
         /// Allows you to use your own application's user id to send OneSignal messages to your user. To tie the user
         /// to a given user id, you can use this method.
@@ -331,6 +331,26 @@ namespace OneSignalSDK {
         /// </summary>
         /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
         public abstract Task<bool> LogOutSMS();
+        
+        /// <summary>
+        /// Current status of this permissions granted by this device for push notifications
+        /// </summary>
+        public abstract PermissionState PermissionState { get; }
+        
+        /// <summary>
+        /// Current status of this device's subscription to push notifications
+        /// </summary>
+        public abstract PushSubscriptionState PushSubscriptionState { get; }
+        
+        /// <summary>
+        /// Current status of this device's subscription to email
+        /// </summary>
+        public abstract EmailSubscriptionState EmailSubscriptionState { get; }
+        
+        /// <summary>
+        /// Current status of this device's subscription to sms
+        /// </summary>
+        public abstract SMSSubscriptionState SMSSubscriptionState { get; }
     #endregion
 
     #region Location

--- a/com.onesignal.unity.core/Runtime/OneSignal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.cs
@@ -133,7 +133,7 @@ namespace OneSignalSDK {
         /// <summary>
         /// When this device's permissions for authorization of push notifications have changed.
         /// </summary>
-        public abstract event StateChangeDelegate<PermissionState> PermissionStateChanged;
+        public abstract event StateChangeDelegate<NotificationPermission> NotificationPermissionChanged;
 
         /// <summary>
         /// When this device's subscription to push notifications has changed
@@ -333,9 +333,9 @@ namespace OneSignalSDK {
         public abstract Task<bool> LogOutSMS();
         
         /// <summary>
-        /// Current status of this permissions granted by this device for push notifications
+        /// Current status of permissions granted by this device for push notifications
         /// </summary>
-        public abstract PermissionState PermissionState { get; }
+        public abstract NotificationPermission NotificationPermission { get; }
         
         /// <summary>
         /// Current status of this device's subscription to push notifications

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.Callbacks.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.Callbacks.cs
@@ -130,9 +130,20 @@ namespace OneSignalSDK {
 
         [AOT.MonoPInvokeCallback(typeof(StateListenerDelegate))]
         private static void _onPermissionStateChanged(string current, string previous) {
-            var curr = JsonUtility.FromJson<PermissionState>(current);
-            var prev = JsonUtility.FromJson<PermissionState>(previous);
-            _instance.PermissionStateChanged?.Invoke(curr, prev);
+            if (!(Json.Deserialize(current) is Dictionary<string, object> currState)) {
+                SDKDebug.Error("Could not deserialize current permission state");
+                return;
+            }
+
+            if (!(Json.Deserialize(previous) is Dictionary<string, object> prevState)) {
+                SDKDebug.Error("Could not deserialize previous permission state");
+                return;
+            }
+            
+            var curr = (NotificationPermission) currState["status"];
+            var prev = (NotificationPermission) prevState["status"];
+            
+            _instance.NotificationPermissionChanged?.Invoke(curr, prev);
         }
         
         [AOT.MonoPInvokeCallback(typeof(StateListenerDelegate))]

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.Interface.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.Interface.cs
@@ -54,6 +54,8 @@ namespace OneSignalSDK {
          * Direct methods
          */
         
+        [DllImport("__Internal")] private static extern string _getDeviceState();
+        
         [DllImport("__Internal")] private static extern void _setPrivacyConsent(bool consent);
         [DllImport("__Internal")] private static extern bool _getPrivacyConsent();
         [DllImport("__Internal")] private static extern void _setRequiresPrivacyConsent(bool required);

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Modified MIT License
  *
  * Copyright 2021 OneSignal
@@ -38,10 +38,20 @@ namespace OneSignalSDK {
         public override event InAppMessageLifecycleDelegate InAppMessageWillDismiss;
         public override event InAppMessageLifecycleDelegate InAppMessageDidDismiss;
         public override event InAppMessageActionDelegate InAppMessageTriggeredAction;
-        public override event StateChangeDelegate<PermissionState> PermissionStateChanged;
+        public override event StateChangeDelegate<NotificationPermission> NotificationPermissionChanged;
         public override event StateChangeDelegate<PushSubscriptionState> PushSubscriptionStateChanged;
         public override event StateChangeDelegate<EmailSubscriptionState> EmailSubscriptionStateChanged;
         public override event StateChangeDelegate<SMSSubscriptionState> SMSSubscriptionStateChanged;
+        
+        public override NotificationPermission NotificationPermission {
+            get {
+                if (Json.Deserialize(_getDeviceState()) is Dictionary<string, object> deviceState)
+                    return (NotificationPermission) deviceState["notificationPermissionStatus"];
+                
+                SDKDebug.Error("Could not deserialize device state for permissions");
+                return NotificationPermission.NotDetermined;
+            }
+        }
         
         public override PushSubscriptionState PushSubscriptionState {
             get {

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
@@ -42,6 +42,52 @@ namespace OneSignalSDK {
         public override event StateChangeDelegate<PushSubscriptionState> PushSubscriptionStateChanged;
         public override event StateChangeDelegate<EmailSubscriptionState> EmailSubscriptionStateChanged;
         public override event StateChangeDelegate<SMSSubscriptionState> SMSSubscriptionStateChanged;
+        
+        public override PushSubscriptionState PushSubscriptionState {
+            get {
+                if (Json.Deserialize(_getDeviceState()) is Dictionary<string, object> deviceState) {
+                    return new PushSubscriptionState {
+                        userId         = deviceState["userId"] as string,
+                        pushToken      = deviceState["pushToken"] as string,
+                        isSubscribed   = (bool) deviceState["isSubscribed"],
+                        isPushDisabled = (bool) deviceState["isPushDisabled"],
+                    };
+                }
+
+                SDKDebug.Error("Could not deserialize device state for push");
+                return null;
+            }
+        }
+        
+        public override EmailSubscriptionState EmailSubscriptionState {
+            get {
+                if (Json.Deserialize(_getDeviceState()) is Dictionary<string, object> deviceState) {
+                    return new EmailSubscriptionState {
+                        emailUserId  = deviceState["emailUserId"] as string,
+                        emailAddress = deviceState["emailAddress"] as string,
+                        isSubscribed = (bool) deviceState["isEmailSubscribed"],
+                    };
+                }
+
+                SDKDebug.Error("Could not deserialize device state for email");
+                return null;
+            }
+        }
+        
+        public override SMSSubscriptionState SMSSubscriptionState {
+            get {
+                if (Json.Deserialize(_getDeviceState()) is Dictionary<string, object> deviceState) {
+                    return new SMSSubscriptionState {
+                        smsUserId    = deviceState["smsUserId"] as string,
+                        smsNumber    = deviceState["smsNumber"] as string,
+                        isSubscribed = (bool) deviceState["isSMSSubscribed"],
+                    };
+                }
+
+                SDKDebug.Error("Could not deserialize device state for sms");
+                return null;
+            }
+        }
 
         public override bool PrivacyConsent {
             get => _getPrivacyConsent();

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridge.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridge.mm
@@ -219,6 +219,12 @@ extern "C" {
     void _setSMSSubscriptionStateChangedCallback(StateListenerDelegate callback) {
         [[OneSignalObserver sharedObserver] setSmsDelegate:callback];
     }
+    
+    const char* _getDeviceState() {
+        auto deviceState = [OneSignal getDeviceState];
+        auto stateStr = jsonStringFromDictionary([deviceState jsonRepresentation]);
+        return strdup(stateStr);
+    }
 
     void _setPrivacyConsent(bool consent) {
         [OneSignal consentGranted: consent];


### PR DESCRIPTION
### Fixed
- Added in missing getters for the permission and subscription states
### Changed
- `PermissionState` has been removed and the `NotficationPermission` enum is reported in its place.
  - Associated event `PermissionStateChanged` has been renamed to `NotificationPermissionChanged`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/421)
<!-- Reviewable:end -->
