### PR TITLE
[FIX] Added missing language setter

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Added missing setter for language which will allow overriding of the default detected language
+- Added missing setter to override the detected language
 - Add missing getters for permission and subscription states
 ### Changed
 - Removed `PermissionState` in favor of `NotificationPermission` enum

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- Added missing setter for language which will allow overriding of the default detected language
 - Add missing getters for permission and subscription states
 ### Changed
 - Removed `PermissionState` in favor of `NotificationPermission` enum

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
@@ -196,6 +196,11 @@ namespace OneSignalSDK {
             _sdkClass.CallStatic("logoutSMSNumber", proxy);
             return await proxy;
         }
+        
+        public override async Task<bool> SetLanguage(string languageCode) {
+            _sdkClass.CallStatic("setLanguage", languageCode);
+            return await Task.FromResult(true); // no callback currently available on Android
+        }
 
         public override void PromptLocation()
             => _sdkClass.CallStatic("promptLocation");

--- a/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
+++ b/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
@@ -141,6 +141,10 @@ namespace OneSignalSDK {
             return Task.FromResult(false);
         }
 
+        public override Task<bool> SetLanguage(string languageCode) {
+            return Task.FromResult(false);
+        }
+
         public override void PromptLocation() {
             
         }

--- a/com.onesignal.unity.core/Runtime/OneSignal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.cs
@@ -331,6 +331,15 @@ namespace OneSignalSDK {
         /// </summary>
         /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
         public abstract Task<bool> LogOutSMS();
+
+        /// <summary>
+        /// Change the system detected language by passing in the desired language code. See
+        /// https://documentation.onesignal.com/docs/language-localization#what-languages-are-supported
+        /// for supported languages.
+        /// </summary>
+        /// <param name="languageCode">ISO 639-1 code representation for user input language</param>
+        /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
+        public abstract Task<bool> SetLanguage(string languageCode);
         
         /// <summary>
         /// Current status of permissions granted by this device for push notifications

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.Interface.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.Interface.cs
@@ -84,6 +84,8 @@ namespace OneSignalSDK {
 
         [DllImport("__Internal")] private static extern void _logoutEmail(int hashCode, BooleanResponseDelegate callback);
         [DllImport("__Internal")] private static extern void _logoutSMSNumber(int hashCode, BooleanResponseDelegate callback);
+        
+        [DllImport("__Internal")] private static extern void _setLanguage(string languageCode, int hashCode, BooleanResponseDelegate callback);
 
         [DllImport("__Internal")] private static extern void _promptLocation();
         [DllImport("__Internal")] private static extern void _setShareLocation(bool share);

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
@@ -215,6 +215,12 @@ namespace OneSignalSDK {
             _logoutSMSNumber(hashCode, BooleanCallbackProxy);
             return await proxy;
         }
+        
+        public override async Task<bool> SetLanguage(string languageCode) {
+            var (proxy, hashCode) = _setupProxy<bool>();
+            _setLanguage(languageCode, hashCode, BooleanCallbackProxy);
+            return await proxy;
+        }
 
         public override void PromptLocation()
             => _promptLocation();

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridge.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridge.mm
@@ -373,6 +373,12 @@ extern "C" {
         [OneSignal logoutSMSNumberWithSuccess:^(NSDictionary *results) { CALLBACK(YES); }
                                   withFailure:^(NSError *error) { CALLBACK(NO); }];
     }
+    
+    void _setLanguage(const char* languageCode, int hashCode, BooleanResponseDelegate callback) {
+        [OneSignal setLanguage:TO_NSSTRING(languageCode)
+                   withSuccess:^{ CALLBACK(YES); }
+                   withFailure:^(NSError *error) { CALLBACK(NO); }];
+    }
 
     void _promptLocation() {
         [OneSignal promptLocation];


### PR DESCRIPTION
### Fixed
- Added missing setter for language which will allow overriding of the default detected language

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/422)
<!-- Reviewable:end -->
