### PR TITLE
[Fix] Properly push log level settings to native SDKs

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added missing setter to override the detected language
 - Add missing getters for permission and subscription states
 ### Changed
-- `LogLevel` and `AlertLevel` now use a custom enum setup to mimic native implementations instead of the Unity `LogType`
+- `LogLevel` and `AlertLevel` now use a custom enum instead of the Unity `LogType`
 - Removed `PermissionState` in favor of `NotificationPermission` enum
   - Renamed `PermissionStateChanged` event to `NotificationPermissionChanged`
 

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- Properly push `LogLevel` and `AlertLevel` settings to native SDKs
 - Added missing setter to override the detected language
 - Add missing getters for permission and subscription states
 ### Changed
+- `LogLevel` and `AlertLevel` now use a custom enum setup to mimic native implementations instead of the Unity `LogType`
 - Removed `PermissionState` in favor of `NotificationPermission` enum
   - Renamed `PermissionStateChanged` event to `NotificationPermissionChanged`
 

--- a/OneSignalExample/Assets/OneSignal/Example/OneSignalExampleBehaviour.cs
+++ b/OneSignalExample/Assets/OneSignal/Example/OneSignalExampleBehaviour.cs
@@ -74,8 +74,8 @@ namespace OneSignalSDK {
         /// </summary>
         private void Start() {
             // Enable lines below to debug issues with OneSignal
-            OneSignal.Default.LogLevel   = LogType.Log;
-            OneSignal.Default.AlertLevel = LogType.Exception;
+            OneSignal.Default.LogLevel   = LogLevel.Info;
+            OneSignal.Default.AlertLevel = LogLevel.Fatal;
 
             // Setting RequiresPrivacyConsent to true will prevent the OneSignalSDK from operating until
             // PrivacyConsent is also set to true

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
@@ -81,6 +81,22 @@ namespace OneSignalSDK {
             }
         }
 
+        public override LogLevel LogLevel {
+            get => _logLevel;
+            set {
+                _logLevel = value;
+                _sdkClass.CallStatic("setLogLevel", _logLevel, _alertLevel);
+            }
+        }
+
+        public override LogLevel AlertLevel {
+            get => _alertLevel;
+            set {
+                _alertLevel = value;
+                _sdkClass.CallStatic("setLogLevel", _logLevel, _alertLevel);
+            }
+        }
+        
         public override bool PrivacyConsent {
             get => _sdkClass.CallStatic<bool>("userProvidedPrivacyConsent");
             set => _sdkClass.CallStatic("provideUserConsent", value);

--- a/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
+++ b/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
@@ -46,6 +46,9 @@ namespace OneSignalSDK {
         public override event StateChangeDelegate<EmailSubscriptionState> EmailSubscriptionStateChanged;
         public override event StateChangeDelegate<SMSSubscriptionState> SMSSubscriptionStateChanged;
 
+        public override LogLevel LogLevel { get; set; }
+        public override LogLevel AlertLevel { get; set; }
+        
         public override bool PrivacyConsent { get; set; }
         public override bool RequiresPrivacyConsent { get; set; }
         

--- a/com.onesignal.unity.core/Runtime/OneSignal.Internal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.Internal.cs
@@ -33,6 +33,9 @@ namespace OneSignalSDK {
         internal static event Action<string> OnInitialize;
         protected static void _completedInit(string appId) => OnInitialize?.Invoke(appId);
         
+        protected LogLevel _logLevel = LogLevel.Fatal;
+        protected LogLevel _alertLevel = LogLevel.None;
+        
         private static OneSignal _default;
 
         private static OneSignal _getDefaultInstance() {
@@ -43,7 +46,7 @@ namespace OneSignalSDK {
             var availableSDKs = ReflectionHelpers.FindAllAssignableTypes<OneSignal>("OneSignal");
             if (Activator.CreateInstance(availableSDKs.First()) is OneSignal sdk) {
                 _default = sdk;
-                SDKDebug.Log($"OneSignal.Default set to platform SDK {sdk.GetType()}. Current version is {Version}");
+                SDKDebug.Info($"OneSignal.Default set to platform SDK {sdk.GetType()}. Current version is {Version}");
             }
             else {
                 SDKDebug.Error("Could not find an implementation of OneSignal SDK to use!");

--- a/com.onesignal.unity.core/Runtime/OneSignal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.cs
@@ -43,7 +43,7 @@ namespace OneSignalSDK {
         public static OneSignal Default {
             get => _getDefaultInstance();
             internal set {
-                SDKDebug.Log($"OneSignal.Default set to platform SDK {value.GetType()}. Current version is {Version}");
+                SDKDebug.Info($"OneSignal.Default set to platform SDK {value.GetType()}. Current version is {Version}");
                 _default = value;
             }
         }
@@ -155,12 +155,12 @@ namespace OneSignalSDK {
         /// <summary>
         /// The minimum level of logs which will be logged to the console
         /// </summary>
-        public LogType LogLevel { get; set; }
+        public abstract LogLevel LogLevel { get; set; }
 
         /// <summary>
         /// The minimum level of log events which will be converted into foreground alerts
         /// </summary>
-        public LogType AlertLevel { get; set; }
+        public abstract LogLevel AlertLevel { get; set; }
 
         /// <summary>
         /// Provides privacy consent. OneSignal Unity SDK will not initialize until this is true.

--- a/com.onesignal.unity.core/Runtime/OneSignalBehaviour.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignalBehaviour.cs
@@ -41,12 +41,12 @@ namespace OneSignalSDK {
         /// <summary>
         /// The minimum level of logs which will be logged to the console
         /// </summary>
-        public LogType LogLevel = LogType.Warning;
+        public LogLevel LogLevel = LogLevel.Warn;
         
         /// <summary>
         /// The minimum level of log events which will be converted into foreground alerts
         /// </summary>
-        public LogType AlertLevel = LogType.Exception;
+        public LogLevel AlertLevel = LogLevel.None;
 
         /// <summary>
         /// Allows you to delay the initialization of the SDK until <see cref="OneSignal.PrivacyConsent"/> is set to

--- a/com.onesignal.unity.core/Runtime/Utilities/SDKDebug.cs
+++ b/com.onesignal.unity.core/Runtime/Utilities/SDKDebug.cs
@@ -30,6 +30,19 @@ using UnityEngine;
 
 namespace OneSignalSDK {
     /// <summary>
+    /// Direct mapping of native SDK log levels
+    /// </summary> 
+    public enum LogLevel {
+        None = 0, 
+        Fatal, 
+        Error, 
+        Warn, 
+        Info, 
+        Debug, 
+        Verbose
+    }
+    
+    /// <summary>
     /// Helper for printing Unity logs formatted to specify they are from this SDK
     /// </summary>
     internal static class SDKDebug {
@@ -37,24 +50,24 @@ namespace OneSignalSDK {
         public static event Action<object> WarnIntercept; 
         public static event Action<object> ErrorIntercept; 
 
-        public static void Log(string message) {
+        public static void Info(string message) {
             if (LogIntercept != null)
                 LogIntercept(message);
-            else if (OneSignal.Default.LogLevel >= LogType.Log)
+            else if (OneSignal.Default.LogLevel >= LogLevel.Info)
                 Debug.Log(_formatMessage(message));
         }
         
         public static void Warn(string message) {
             if (WarnIntercept != null)
                 WarnIntercept(message);
-            else if (OneSignal.Default.LogLevel >= LogType.Warning)
+            else if (OneSignal.Default.LogLevel >= LogLevel.Warn)
                 Debug.LogWarning(_formatMessage(message));
         }
         
         public static void Error(string message) {
             if (ErrorIntercept != null)
                 ErrorIntercept(message);
-            else  if (OneSignal.Default.LogLevel >= LogType.Error)
+            else  if (OneSignal.Default.LogLevel >= LogLevel.Error)
                 Debug.LogError(_formatMessage(message));
         }
         

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.Interface.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.Interface.cs
@@ -56,6 +56,7 @@ namespace OneSignalSDK {
         
         [DllImport("__Internal")] private static extern string _getDeviceState();
         
+        [DllImport("__Internal")] private static extern void _setLogLevel(int logLevel, int alertLevel);
         [DllImport("__Internal")] private static extern void _setPrivacyConsent(bool consent);
         [DllImport("__Internal")] private static extern bool _getPrivacyConsent();
         [DllImport("__Internal")] private static extern void _setRequiresPrivacyConsent(bool required);

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
@@ -99,6 +99,22 @@ namespace OneSignalSDK {
             }
         }
 
+        public override LogLevel LogLevel {
+            get => _logLevel;
+            set {
+                _logLevel = value;
+                _setLogLevel((int) _logLevel, (int) _alertLevel);
+            }
+        }
+
+        public override LogLevel AlertLevel {
+            get => _alertLevel;
+            set {
+                _alertLevel = value;
+                _setLogLevel((int) _logLevel, (int) _alertLevel);
+            }
+        }
+        
         public override bool PrivacyConsent {
             get => _getPrivacyConsent();
             set => _setPrivacyConsent(value);
@@ -121,7 +137,7 @@ namespace OneSignalSDK {
         }
 
         public override void ClearOneSignalNotifications()
-            => SDKDebug.Log("ClearOneSignalNotifications invoked on iOS, does nothing");
+            => SDKDebug.Info("ClearOneSignalNotifications invoked on iOS, does nothing");
 
         public override async Task<Dictionary<string, object>> PostNotification(Dictionary<string, object> options) {
             var (proxy, hashCode) = _setupProxy<string>();

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridge.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridge.mm
@@ -67,10 +67,10 @@ const char* jsonStringFromDictionary(NSDictionary *dictionary) {
  */
 
 @interface OneSignalObserver : NSObject <OSPermissionObserver,
-                                         OSSubscriptionObserver,
-                                         OSEmailSubscriptionObserver,
-                                         OSSMSSubscriptionObserver,
-                                         OSInAppMessageLifecycleHandler>
+        OSSubscriptionObserver,
+        OSEmailSubscriptionObserver,
+        OSSMSSubscriptionObserver,
+        OSInAppMessageLifecycleHandler>
 
 + (instancetype) sharedObserver;
 @property StateListenerDelegate permissionDelegate;
@@ -167,54 +167,54 @@ const char* jsonStringFromDictionary(NSDictionary *dictionary) {
 
 extern "C" {
 
-    void _setNotificationReceivedCallback(NotificationWillShowInForegroundDelegate callback) {
-        [OneSignal setNotificationWillShowInForegroundHandler:^(OSNotification *notification, OSNotificationDisplayResponse completion) {
-            NSString *stringResponse = [notification stringify];
-            bool shouldDisplay = callback([stringResponse UTF8String]);
-            completion(shouldDisplay ? notification : nil);
-        }];
-    }
+void _setNotificationReceivedCallback(NotificationWillShowInForegroundDelegate callback) {
+    [OneSignal setNotificationWillShowInForegroundHandler:^(OSNotification *notification, OSNotificationDisplayResponse completion) {
+        NSString *stringResponse = [notification stringify];
+        bool shouldDisplay = callback([stringResponse UTF8String]);
+        completion(shouldDisplay ? notification : nil);
+    }];
+}
 
-    void _setNotificationOpenedCallback(StringListenerDelegate callback) {
-        [OneSignal setNotificationOpenedHandler:^(OSNotificationOpenedResult * _Nonnull result) {
-            NSString *stringResponse = [result stringify];
-            callback([stringResponse UTF8String]);
-        }];
-    }
+void _setNotificationOpenedCallback(StringListenerDelegate callback) {
+    [OneSignal setNotificationOpenedHandler:^(OSNotificationOpenedResult * _Nonnull result) {
+        NSString *stringResponse = [result stringify];
+        callback([stringResponse UTF8String]);
+    }];
+}
 
-    void _setInAppMessageWillDisplayCallback(StringListenerDelegate callback) {
-        [[OneSignalObserver sharedObserver] setIamWillDisplayDelegate:callback];
-    }
+void _setInAppMessageWillDisplayCallback(StringListenerDelegate callback) {
+    [[OneSignalObserver sharedObserver] setIamWillDisplayDelegate:callback];
+}
 
-    void _setInAppMessageDidDisplayCallback(StringListenerDelegate callback) {
-        [[OneSignalObserver sharedObserver] setIamDidDisplayDelegate:callback];
-    }
+void _setInAppMessageDidDisplayCallback(StringListenerDelegate callback) {
+    [[OneSignalObserver sharedObserver] setIamDidDisplayDelegate:callback];
+}
 
-    void _setInAppMessageWillDismissCallback(StringListenerDelegate callback) {
-        [[OneSignalObserver sharedObserver] setIamWillDismissDelegate:callback];
-    }
+void _setInAppMessageWillDismissCallback(StringListenerDelegate callback) {
+    [[OneSignalObserver sharedObserver] setIamWillDismissDelegate:callback];
+}
 
-    void _setInAppMessageDidDismissCallback(StringListenerDelegate callback) {
-        [[OneSignalObserver sharedObserver] setIamDidDismissDelegate:callback];
-    }
+void _setInAppMessageDidDismissCallback(StringListenerDelegate callback) {
+    [[OneSignalObserver sharedObserver] setIamDidDismissDelegate:callback];
+}
 
-    void _setInAppMessageClickedCallback(StringListenerDelegate callback) {
-        [OneSignal setInAppMessageClickHandler:^(OSInAppMessageAction * _Nonnull action) {
-            callback(jsonStringFromDictionary([action jsonRepresentation]));
-        }];
-    }
+void _setInAppMessageClickedCallback(StringListenerDelegate callback) {
+    [OneSignal setInAppMessageClickHandler:^(OSInAppMessageAction * _Nonnull action) {
+        callback(jsonStringFromDictionary([action jsonRepresentation]));
+    }];
+}
 
-    void _setPermissionStateChangedCallback(StateListenerDelegate callback) {
-        [[OneSignalObserver sharedObserver] setPermissionDelegate:callback];
-    }
+void _setPermissionStateChangedCallback(StateListenerDelegate callback) {
+    [[OneSignalObserver sharedObserver] setPermissionDelegate:callback];
+}
 
-    void _setSubscriptionStateChangedCallback(StateListenerDelegate callback) {
-        [[OneSignalObserver sharedObserver] setSubscriptionDelegate:callback];
-    }
+void _setSubscriptionStateChangedCallback(StateListenerDelegate callback) {
+    [[OneSignalObserver sharedObserver] setSubscriptionDelegate:callback];
+}
 
-    void _setEmailSubscriptionStateChangedCallback(StateListenerDelegate callback) {
-        [[OneSignalObserver sharedObserver] setEmailDelegate:callback];
-    }
+void _setEmailSubscriptionStateChangedCallback(StateListenerDelegate callback) {
+    [[OneSignalObserver sharedObserver] setEmailDelegate:callback];
+}
 
     void _setSMSSubscriptionStateChangedCallback(StateListenerDelegate callback) {
         [[OneSignalObserver sharedObserver] setSmsDelegate:callback];
@@ -226,151 +226,156 @@ extern "C" {
         return strdup(stateStr);
     }
 
-    void _setPrivacyConsent(bool consent) {
-        [OneSignal consentGranted: consent];
+void _setLogLevel(int logLevel, int alertLevel) {
+    [OneSignal setLogLevel:(ONE_S_LOG_LEVEL) logLevel
+               visualLevel:(ONE_S_LOG_LEVEL) alertLevel];
+}
+
+void _setPrivacyConsent(bool consent) {
+    [OneSignal consentGranted: consent];
+}
+
+bool _getPrivacyConsent() {
+    return false; // todo - doesn't exist
+}
+
+void _setRequiresPrivacyConsent(bool required) {
+    [OneSignal setRequiresUserPrivacyConsent: required];
+}
+
+bool _getRequiresPrivacyConsent() {
+    return [OneSignal requiresUserPrivacyConsent];
+}
+
+void _initialize(const char* appId) {
+    [OneSignal setAppId:TO_NSSTRING(appId)];
+    [OneSignal initWithLaunchOptions:nil];
+}
+
+void _promptForPushNotificationsWithUserResponse(int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
+        CALLBACK(accepted);
+    }];
+}
+
+void _postNotification(const char* optionsJson, int hashCode, StringResponseDelegate callback) {
+    NSDictionary *options = objFromJsonString<NSDictionary*>(optionsJson);
+
+    [OneSignal postNotification:options onSuccess:^(NSDictionary *result) {
+        CALLBACK(jsonStringFromDictionary(result));
+    } onFailure:^(NSError *error) {
+        CALLBACK(NULL);
+    }];
+}
+
+void _setTrigger(const char* key, const char* value) {
+    [OneSignal addTrigger:TO_NSSTRING(key) withValue:TO_NSSTRING(value)];
+}
+
+void _setTriggers(const char* triggersJson) {
+    NSDictionary *triggers = objFromJsonString<NSDictionary*>(triggersJson);
+    [OneSignal addTriggers:triggers];
+}
+
+void _removeTrigger(const char* key) {
+    [OneSignal removeTriggerForKey:TO_NSSTRING(key)];
+}
+
+void _removeTriggers(const char* triggersJson) {
+    NSArray *triggers = objFromJsonString<NSArray*>(triggersJson);
+    [OneSignal removeTriggersForKeys:triggers];
+}
+
+const char* _getTrigger(const char* key) {
+    id value = [OneSignal getTriggerValueForKey:TO_NSSTRING(key)];
+    NSString *asString = [NSString stringWithFormat:@"%@", value];
+    return strdup([asString UTF8String]);
+}
+
+const char* _getTriggers() {
+    NSDictionary *triggers = [OneSignal getTriggers];
+    return strdup(jsonStringFromDictionary(triggers));
+}
+
+void _setInAppMessagesArePaused(bool paused) {
+    [OneSignal pauseInAppMessages:paused];
+}
+
+bool _getInAppMessagesArePaused() {
+    return [OneSignal isInAppMessagingPaused];
+}
+
+void _sendTag(const char* name, const char* value, int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal sendTag:TO_NSSTRING(name)
+                 value:TO_NSSTRING(value)
+             onSuccess:^(NSDictionary *result) { CALLBACK(YES); }
+             onFailure:^(NSError *error) { CALLBACK(NO); }];
+}
+
+void _sendTags(const char* tagsJson, int hashCode, BooleanResponseDelegate callback) {
+    NSDictionary *tags = objFromJsonString<NSDictionary*>(tagsJson);
+
+    [OneSignal sendTags:tags
+              onSuccess:^(NSDictionary *result) { CALLBACK(YES); }
+              onFailure:^(NSError *error) { CALLBACK(NO); }];
+}
+
+void _getTags(int hashCode, StringResponseDelegate callback) {
+    [OneSignal getTags:^(NSDictionary *result) {
+        CALLBACK(jsonStringFromDictionary(result));
+    } onFailure:^(NSError *error) {
+        NSLog(@"[Onesignal] Could not get tags");
+        CALLBACK(nil);
+    }];
+}
+
+void _deleteTag(const char* name, int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal deleteTag:TO_NSSTRING(name)
+               onSuccess:^(NSDictionary *result) { CALLBACK(YES); }
+               onFailure:^(NSError *error) { CALLBACK(NO); }];
+}
+
+void _deleteTags(const char* tagsJson, int hashCode, BooleanResponseDelegate callback) {
+    NSArray *tags = objFromJsonString<NSArray*>(tagsJson);
+
+    if (tags == nil) {
+        NSLog(@"[Onesignal] Could not parse tags to delete");
+        CALLBACK(NO);
     }
 
-    bool _getPrivacyConsent() {
-        return false; // todo - doesn't exist
-    }
+    [OneSignal deleteTags:tags
+                onSuccess:^(NSDictionary *result) { CALLBACK(YES); }
+                onFailure:^(NSError *error) { CALLBACK(NO); }];
+}
 
-    void _setRequiresPrivacyConsent(bool required) {
-        [OneSignal setRequiresUserPrivacyConsent: required];
-    }
+void _setExternalUserId(const char* externalId, const char* authHash, int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal setExternalUserId:TO_NSSTRING(externalId)
+     withExternalIdAuthHashToken:TO_NSSTRING(authHash)
+                     withSuccess:^(NSDictionary *results) { CALLBACK(YES); }
+                     withFailure:^(NSError *error) { CALLBACK(NO); }];
+}
 
-    bool _getRequiresPrivacyConsent() {
-        return [OneSignal requiresUserPrivacyConsent];
-    }
+void _setEmail(const char* email, const char* authHash, int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal setEmail:TO_NSSTRING(email)
+ withEmailAuthHashToken:TO_NSSTRING(authHash)
+            withSuccess:^{ CALLBACK(YES); }
+            withFailure:^(NSError *error) { CALLBACK(NO); }];
+}
 
-    void _initialize(const char* appId) {
-        [OneSignal setAppId:TO_NSSTRING(appId)];
-        [OneSignal initWithLaunchOptions:nil];
-    }
-
-    void _promptForPushNotificationsWithUserResponse(int hashCode, BooleanResponseDelegate callback) {
-        [OneSignal promptForPushNotificationsWithUserResponse:^(BOOL accepted) {
-            CALLBACK(accepted);
-        }];
-    }
-
-    void _postNotification(const char* optionsJson, int hashCode, StringResponseDelegate callback) {
-        NSDictionary *options = objFromJsonString<NSDictionary*>(optionsJson);
-
-        [OneSignal postNotification:options onSuccess:^(NSDictionary *result) {
-            CALLBACK(jsonStringFromDictionary(result));
-        } onFailure:^(NSError *error) {
-            CALLBACK(NULL);
-        }];
-    }
-
-    void _setTrigger(const char* key, const char* value) {
-        [OneSignal addTrigger:TO_NSSTRING(key) withValue:TO_NSSTRING(value)];
-    }
-
-    void _setTriggers(const char* triggersJson) {
-        NSDictionary *triggers = objFromJsonString<NSDictionary*>(triggersJson);
-        [OneSignal addTriggers:triggers];
-    }
-
-    void _removeTrigger(const char* key) {
-        [OneSignal removeTriggerForKey:TO_NSSTRING(key)];
-    }
-
-    void _removeTriggers(const char* triggersJson) {
-        NSArray *triggers = objFromJsonString<NSArray*>(triggersJson);
-        [OneSignal removeTriggersForKeys:triggers];
-    }
-
-    const char* _getTrigger(const char* key) {
-        id value = [OneSignal getTriggerValueForKey:TO_NSSTRING(key)];
-        NSString *asString = [NSString stringWithFormat:@"%@", value];
-        return strdup([asString UTF8String]);
-    }
-
-    const char* _getTriggers() {
-        NSDictionary *triggers = [OneSignal getTriggers];
-        return strdup(jsonStringFromDictionary(triggers));
-    }
-
-    void _setInAppMessagesArePaused(bool paused) {
-        [OneSignal pauseInAppMessages:paused];
-    }
-
-    bool _getInAppMessagesArePaused() {
-        return [OneSignal isInAppMessagingPaused];
-    }
-
-    void _sendTag(const char* name, const char* value, int hashCode, BooleanResponseDelegate callback) {
-        [OneSignal sendTag:TO_NSSTRING(name)
-                     value:TO_NSSTRING(value)
-                 onSuccess:^(NSDictionary *result) { CALLBACK(YES); }
-                 onFailure:^(NSError *error) { CALLBACK(NO); }];
-    }
-
-    void _sendTags(const char* tagsJson, int hashCode, BooleanResponseDelegate callback) {
-        NSDictionary *tags = objFromJsonString<NSDictionary*>(tagsJson);
-
-        [OneSignal sendTags:tags
-                  onSuccess:^(NSDictionary *result) { CALLBACK(YES); }
-                  onFailure:^(NSError *error) { CALLBACK(NO); }];
-    }
-
-    void _getTags(int hashCode, StringResponseDelegate callback) {
-        [OneSignal getTags:^(NSDictionary *result) {
-            CALLBACK(jsonStringFromDictionary(result));
-        } onFailure:^(NSError *error) {
-            NSLog(@"[Onesignal] Could not get tags");
-            CALLBACK(nil);
-        }];
-    }
-
-    void _deleteTag(const char* name, int hashCode, BooleanResponseDelegate callback) {
-        [OneSignal deleteTag:TO_NSSTRING(name)
-                   onSuccess:^(NSDictionary *result) { CALLBACK(YES); }
-                   onFailure:^(NSError *error) { CALLBACK(NO); }];
-    }
-
-    void _deleteTags(const char* tagsJson, int hashCode, BooleanResponseDelegate callback) {
-        NSArray *tags = objFromJsonString<NSArray*>(tagsJson);
-
-        if (tags == nil) {
-            NSLog(@"[Onesignal] Could not parse tags to delete");
-            CALLBACK(NO);
-        }
-
-        [OneSignal deleteTags:tags
-                    onSuccess:^(NSDictionary *result) { CALLBACK(YES); }
-                    onFailure:^(NSError *error) { CALLBACK(NO); }];
-    }
-
-    void _setExternalUserId(const char* externalId, const char* authHash, int hashCode, BooleanResponseDelegate callback) {
-        [OneSignal setExternalUserId:TO_NSSTRING(externalId)
-         withExternalIdAuthHashToken:TO_NSSTRING(authHash)
-                         withSuccess:^(NSDictionary *results) { CALLBACK(YES); }
-                         withFailure:^(NSError *error) { CALLBACK(NO); }];
-    }
-
-    void _setEmail(const char* email, const char* authHash, int hashCode, BooleanResponseDelegate callback) {
-        [OneSignal setEmail:TO_NSSTRING(email)
-     withEmailAuthHashToken:TO_NSSTRING(authHash)
-                withSuccess:^{ CALLBACK(YES); }
+void _setSMSNumber(const char* smsNumber, const char* authHash, int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal setSMSNumber:TO_NSSTRING(smsNumber)
+       withSMSAuthHashToken:TO_NSSTRING(authHash)
+                withSuccess:^(NSDictionary *results) { CALLBACK(YES); }
                 withFailure:^(NSError *error) { CALLBACK(NO); }];
-    }
+}
 
-    void _setSMSNumber(const char* smsNumber, const char* authHash, int hashCode, BooleanResponseDelegate callback) {
-        [OneSignal setSMSNumber:TO_NSSTRING(smsNumber)
-           withSMSAuthHashToken:TO_NSSTRING(authHash)
-                    withSuccess:^(NSDictionary *results) { CALLBACK(YES); }
-                    withFailure:^(NSError *error) { CALLBACK(NO); }];
-    }
-    
-    void _logoutEmail(int hashCode, BooleanResponseDelegate callback) {
-        [OneSignal logoutEmailWithSuccess:^{ CALLBACK(YES); }
-                              withFailure:^(NSError *error) { CALLBACK(NO); }];
-    }
-    
-    void _logoutSMSNumber(int hashCode, BooleanResponseDelegate callback) {
-        [OneSignal logoutSMSNumberWithSuccess:^(NSDictionary *results) { CALLBACK(YES); }
+void _logoutEmail(int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal logoutEmailWithSuccess:^{ CALLBACK(YES); }
+                          withFailure:^(NSError *error) { CALLBACK(NO); }];
+}
+
+void _logoutSMSNumber(int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal logoutSMSNumberWithSuccess:^(NSDictionary *results) { CALLBACK(YES); }
                                   withFailure:^(NSError *error) { CALLBACK(NO); }];
     }
     
@@ -384,29 +389,29 @@ extern "C" {
         [OneSignal promptLocation];
     }
 
-    void _setShareLocation(bool share) {
-        [OneSignal setLocationShared:share];
-    }
-
-    bool _getShareLocation() {
-        return [OneSignal isLocationShared];
-    }
-
-    void _sendOutcome(const char* name, int hashCode, BooleanResponseDelegate callback) {
-        [OneSignal sendOutcome:TO_NSSTRING(name)
-                     onSuccess:^(OSOutcomeEvent *outcome) { CALLBACK(outcome != nil); }];
-    }
-
-    void _sendUniqueOutcome(const char* name, int hashCode, BooleanResponseDelegate callback) {
-        [OneSignal sendUniqueOutcome:TO_NSSTRING(name)
-                           onSuccess:^(OSOutcomeEvent *outcome) { CALLBACK(outcome != nil); }];
-    }
-
-    void _sendOutcomeWithValue(const char* name, float value, int hashCode, BooleanResponseDelegate callback) {
-        [OneSignal sendOutcomeWithValue:TO_NSSTRING(name)
-                                  value:@(value)
-                              onSuccess:^(OSOutcomeEvent *outcome) { CALLBACK(outcome != nil); }];
-    }
+void _setShareLocation(bool share) {
+    [OneSignal setLocationShared:share];
 }
 
- 
+bool _getShareLocation() {
+    return [OneSignal isLocationShared];
+}
+
+void _sendOutcome(const char* name, int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal sendOutcome:TO_NSSTRING(name)
+                 onSuccess:^(OSOutcomeEvent *outcome) { CALLBACK(outcome != nil); }];
+}
+
+void _sendUniqueOutcome(const char* name, int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal sendUniqueOutcome:TO_NSSTRING(name)
+                       onSuccess:^(OSOutcomeEvent *outcome) { CALLBACK(outcome != nil); }];
+}
+
+void _sendOutcomeWithValue(const char* name, float value, int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal sendOutcomeWithValue:TO_NSSTRING(name)
+                              value:@(value)
+                          onSuccess:^(OSOutcomeEvent *outcome) { CALLBACK(outcome != nil); }];
+}
+}
+
+


### PR DESCRIPTION
### Fixed
- Properly push `LogLevel` and `AlertLevel` settings to native SDKs
### Changed
- `LogLevel` and `AlertLevel` now use a custom enum setup to mimic native implementations instead of the Unity `LogType`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/423)
<!-- Reviewable:end -->
