### PR TITLE
[Fix] Setup Android global callbacks post initWithContext

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Eliminated syntax only supported on Unity 2020 or above
+- Global callbacks on Android are now correctly setup post `initWithContext`
 - Properly push `LogLevel` and `AlertLevel` settings to native SDKs
 - Added missing setter to override the detected language
 - Add missing getters for permission and subscription states

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.Callbacks.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.Callbacks.cs
@@ -68,27 +68,11 @@ namespace OneSignalSDK {
         private static OneSignalAndroid _instance;
 
         /// <summary>
-        /// Used to provide a reference for and sets up the global callbacks
+        /// Used to provide a reference for the global callbacks
         /// </summary>
         public OneSignalAndroid() {
             if (_instance != null)
                 SDKDebug.Error("Additional instance of OneSignalAndroid created.");
-            
-            // states
-            _sdkClass.CallStatic("addPermissionObserver", new OSPermissionObserver());
-            _sdkClass.CallStatic("addSubscriptionObserver", new OSSubscriptionObserver());
-            _sdkClass.CallStatic("addEmailSubscriptionObserver", new OSEmailSubscriptionObserver());
-            _sdkClass.CallStatic("addSMSSubscriptionObserver", new OSSMSSubscriptionObserver());
-            
-            // notifications
-            _sdkClass.CallStatic("setNotificationWillShowInForegroundHandler", new OSNotificationWillShowInForegroundHandler());
-            _sdkClass.CallStatic("setNotificationOpenedHandler", new OSNotificationOpenedHandler());
-
-            // iams
-            _sdkClass.CallStatic("setInAppMessageClickHandler", new OSInAppMessageClickHandler());
-            
-            var wrapperHandler = new AndroidJavaObject(QualifiedIAMLifecycleClass, new OSInAppMessageLifecycleHandler());
-            _sdkClass.CallStatic("setInAppMessageLifecycleHandler", wrapperHandler);
 
             _instance = this;
         }

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
@@ -112,6 +112,23 @@ namespace OneSignalSDK {
             var activity    = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
 
             _sdkClass.CallStatic("initWithContext", activity);
+                        
+            // states
+            _sdkClass.CallStatic("addPermissionObserver", new OSPermissionObserver());
+            _sdkClass.CallStatic("addSubscriptionObserver", new OSSubscriptionObserver());
+            _sdkClass.CallStatic("addEmailSubscriptionObserver", new OSEmailSubscriptionObserver());
+            _sdkClass.CallStatic("addSMSSubscriptionObserver", new OSSMSSubscriptionObserver());
+            
+            // notifications
+            _sdkClass.CallStatic("setNotificationWillShowInForegroundHandler", new OSNotificationWillShowInForegroundHandler());
+            _sdkClass.CallStatic("setNotificationOpenedHandler", new OSNotificationOpenedHandler());
+
+            // iams
+            _sdkClass.CallStatic("setInAppMessageClickHandler", new OSInAppMessageClickHandler());
+            
+            var wrapperHandler = new AndroidJavaObject(QualifiedIAMLifecycleClass, new OSInAppMessageLifecycleHandler());
+            _sdkClass.CallStatic("setInAppMessageLifecycleHandler", wrapperHandler);
+            
             _sdkClass.CallStatic("setAppId", appId);
 
             _completedInit(appId);


### PR DESCRIPTION
### Fixed
- Global callbacks on Android are now correctly setup post `initWithContext`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/424)
<!-- Reviewable:end -->
