### PR TITLE
[Fix] Removed unsupported syntax

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- Eliminated syntax only supported on Unity 2020 or above
 - Properly push `LogLevel` and `AlertLevel` settings to native SDKs
 - Added missing setter to override the detected language
 - Add missing getters for permission and subscription states

--- a/com.onesignal.unity.android/Runtime/Utilities/AndroidJavaObjectExtensions.cs
+++ b/com.onesignal.unity.android/Runtime/Utilities/AndroidJavaObjectExtensions.cs
@@ -100,11 +100,12 @@ namespace OneSignalSDK {
 
             var entryArgs = new object[2];
             foreach (var kv in source) {
-                using var key = new AndroidJavaObject("java.lang.String", kv.Key);
-                using var value = new AndroidJavaObject("java.lang.String", kv.Value);
-                entryArgs[0] = key;
-                entryArgs[1] = value;
-                AndroidJNI.CallObjectMethod(map.GetRawObject(), put, AndroidJNIHelper.CreateJNIArgArray(entryArgs));
+                using (var key = new AndroidJavaObject("java.lang.String", kv.Key))
+                using (var value = new AndroidJavaObject("java.lang.String", kv.Value)) {
+                    entryArgs[0] = key;
+                    entryArgs[1] = value;
+                    AndroidJNI.CallObjectMethod(map.GetRawObject(), put, AndroidJNIHelper.CreateJNIArgArray(entryArgs));
+                }    
             }
             
             return map;


### PR DESCRIPTION
### Fixed
- Eliminated syntax only supported on Unity 2020 or above

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/426)
<!-- Reviewable:end -->
