### PR TITLE
[FIX] Use default debug logging on initialization

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - `NotificationPermission` return from native SDK no longer raises a casting exception on iOS
+- Resolved infinite loop on logging error when OneSignal classes cannot be found
 
 ## [3.0.0-beta.3]
 ### Fixed

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - `NotificationPermission` return from native SDK no longer raises a casting exception on iOS
-- Resolved infinite loop on logging error when OneSignal classes cannot be found
+- Resolved infinite loops on logging initialization conditions
 
 ## [3.0.0-beta.3]
 ### Fixed

--- a/com.onesignal.unity.core/Runtime/OneSignal.Internal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.Internal.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Linq;
+using UnityEngine;
 
 namespace OneSignalSDK {
     public abstract partial class OneSignal {
@@ -49,7 +50,7 @@ namespace OneSignalSDK {
                 SDKDebug.Info($"OneSignal.Default set to platform SDK {sdk.GetType()}. Current version is {Version}");
             }
             else {
-                SDKDebug.Error("Could not find an implementation of OneSignal SDK to use!");
+                Debug.LogError("[OneSignal] Could not find an implementation of OneSignal SDK to use!");
             }
             
             return _default;

--- a/com.onesignal.unity.core/Runtime/OneSignal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.cs
@@ -43,7 +43,7 @@ namespace OneSignalSDK {
         public static OneSignal Default {
             get => _getDefaultInstance();
             internal set {
-                SDKDebug.Info($"OneSignal.Default set to platform SDK {value.GetType()}. Current version is {Version}");
+                Debug.Log($"[OneSignal] OneSignal.Default set to platform SDK {value.GetType()}. Current version is {Version}");
                 _default = value;
             }
         }


### PR DESCRIPTION
### Fixed
- Resolved infinite loops on logging initialization conditions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/432)
<!-- Reviewable:end -->
