### PR TITLE
[FIX] Exception on get NotificationPermission

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `NotificationPermission` return from native SDK no longer raises a casting exception on iOS
+
 ## [3.0.0-beta.3]
 ### Fixed
 - Eliminated syntax only supported on Unity 2020 or above

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
@@ -45,8 +45,10 @@ namespace OneSignalSDK {
         
         public override NotificationPermission NotificationPermission {
             get {
-                if (Json.Deserialize(_getDeviceState()) is Dictionary<string, object> deviceState)
-                    return (NotificationPermission) deviceState["notificationPermissionStatus"];
+                if (Json.Deserialize(_getDeviceState()) is Dictionary<string, object> deviceState) {
+                    if (deviceState["notificationPermissionStatus"] is long status)
+                        return (NotificationPermission) status;
+                }
                 
                 SDKDebug.Error("Could not deserialize device state for permissions");
                 return NotificationPermission.NotDetermined;


### PR DESCRIPTION
### Fixed
- `NotificationPermission` return from native SDK no longer raises a casting exception on iOS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/433)
<!-- Reviewable:end -->
