### PR TITLE
[FEATURE] Setup step to sync example code

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Included a new setup step from the OneSignal Unity Editor menu (**Window > OneSignal**) which syncs the example code bundle with the core package version
 ### Fixed
 - `NotificationPermission` return from native SDK no longer raises a casting exception on iOS
 - Resolved infinite loops on logging initialization conditions

--- a/OneSignalExample/Assets/OneSignal/Editor/Setup/OneSignalSetupWindow.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/Setup/OneSignalSetupWindow.cs
@@ -158,7 +158,7 @@ public sealed class OneSignalSetupWindow : EditorWindow
         _requiredStyle = new GUIStyle(EditorStyles.miniBoldLabel);
         _requiredStyle.normal.textColor = Color.red;
 
-        _optionalStyle = new GUIStyle(EditorStyles.miniLabel);
+        _optionalStyle = new GUIStyle(EditorStyles.miniBoldLabel);
         _optionalStyle.normal.textColor = Color.yellow;
         _optionalStyle.fontStyle = FontStyle.Italic;
 

--- a/com.onesignal.unity.android/Editor/SetupSteps/InstallEdm4uStep.cs
+++ b/com.onesignal.unity.android/Editor/SetupSteps/InstallEdm4uStep.cs
@@ -1,8 +1,5 @@
-using System.IO;
 using System.Linq;
-using UnityEditor;
 using UnityEditor.Compilation;
-using UnityEngine;
 
 /// <summary>
 /// Checks for EDM4U assemblies and installs the package from its github releases
@@ -23,27 +20,14 @@ public sealed class InstallEdm4uStep : OneSignalSetupStep {
            .Any(assemblyName => assemblyName.StartsWith("Google.VersionHandler"));
 
     protected override void _runStep() {
-        var request = EditorWebRequest.Get(_edm4UPackageDownloadUrl);
-        request.AddEditorProgressDialog("Downloading Google External Dependency Manager");
-        request.Send(unityRequest => {
-            if (unityRequest.error != null) {
-                EditorUtility.DisplayDialog("Package Download failed.", unityRequest.error, "Ok");
-                return;
-            }
-
-            //Asset folder name remove
-            var projectPath = Application.dataPath.Substring(0, Application.dataPath.Length - 6);
-            var tmpPackageFile = projectPath + FileUtil.GetUniqueTempPathInProject() + ".unityPackage";
-
-            File.WriteAllBytes(tmpPackageFile, unityRequest.downloadHandler.data);
-            AssetDatabase.ImportPackage(tmpPackageFile, false);
-            
-            _shouldCheckForCompletion = true;
+        const string msg = "Downloading Google External Dependency Manager";
+        UnityPackageInstaller.DownloadAndInstall(_edm4UPackageDownloadUrl, msg, result => {
+            if (result)
+                _shouldCheckForCompletion = true;
         });
     }
 
     private const string _edm4UVersion = "1.2.167";
-
-    static readonly string _edm4UPackageDownloadUrl
+    private static readonly string _edm4UPackageDownloadUrl
         = $"https://github.com/googlesamples/unity-jar-resolver/blob/v{_edm4UVersion}/external-dependency-manager-{_edm4UVersion}.unitypackage?raw=true";
 }

--- a/com.onesignal.unity.core/Editor/Setup/OneSignalSetupWindow.cs
+++ b/com.onesignal.unity.core/Editor/Setup/OneSignalSetupWindow.cs
@@ -158,7 +158,7 @@ public sealed class OneSignalSetupWindow : EditorWindow
         _requiredStyle = new GUIStyle(EditorStyles.miniBoldLabel);
         _requiredStyle.normal.textColor = Color.red;
 
-        _optionalStyle = new GUIStyle(EditorStyles.miniLabel);
+        _optionalStyle = new GUIStyle(EditorStyles.miniBoldLabel);
         _optionalStyle.normal.textColor = Color.yellow;
         _optionalStyle.fontStyle = FontStyle.Italic;
 

--- a/com.onesignal.unity.core/Editor/SetupSteps/SyncCodeBundleStep.cs
+++ b/com.onesignal.unity.core/Editor/SetupSteps/SyncCodeBundleStep.cs
@@ -1,0 +1,85 @@
+/*
+* Modified MIT License
+* 
+* Copyright 2022 OneSignal
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* 
+* 1. The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+* 
+* 2. All copies of substantial portions of the Software may only be used in connection
+* with services provided by OneSignal.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Checks if this code bundle is of a mismatched version than the currently imported packages and updates
+/// </summary>
+public sealed class SyncCodeBundleStep : OneSignalSetupStep {
+    public override string Summary
+        => "Sync example code bundle";
+
+    public override string Details
+        => "Checks if the project scope code bundle (example code) is of a mismatched version than the currently " +
+            "imported packages";
+
+    public override bool IsRequired
+        => false;
+
+    protected override bool _getIsStepCompleted() {
+        if (!File.Exists(_packageJsonPath)) {
+            Debug.LogError("Could not find package.json");
+
+            return true;
+        }
+
+        var packageJson = File.ReadAllText(_packageJsonPath);
+
+        if (Json.Deserialize(packageJson) is Dictionary<string, object> packageInfo) {
+            _sdkVersion = packageInfo["version"] as string;
+
+            return _bundleVersion == _sdkVersion;
+        }
+
+        Debug.LogError("Could not deserialize package.json");
+
+        return true;
+    }
+
+    protected override void _runStep() {
+        var msg = $"Downloading OneSignal Unity SDK {_sdkVersion}";
+        UnityPackageInstaller.DownloadAndInstall(_onesignalUnityPackageDownloadUrl, msg, result => {
+            if (!result)
+                _shouldCheckForCompletion = true;
+        });
+    }
+
+    private static readonly string _versionPath = Path.Combine("Assets", "OneSignal", "VERSION");
+    private static string _bundleVersion => File.ReadAllText(_versionPath);
+
+    private static string _onesignalUnityPackageDownloadUrl
+        => $"https://github.com/OneSignal/OneSignal-Unity-SDK/blob/{_sdkVersion}/OneSignal-v{_sdkVersion}.unitypackage";
+
+    private static readonly string _packagePath = Path.Combine("Packages", "com.onesignal.unity.core");
+    private static readonly string _packageJsonPath = Path.Combine(_packagePath, "package.json");
+
+    private static string _sdkVersion;
+}

--- a/com.onesignal.unity.core/Editor/SetupSteps/SyncCodeBundleStep.cs.meta
+++ b/com.onesignal.unity.core/Editor/SetupSteps/SyncCodeBundleStep.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 918abb35930335c48a68a1f9b0c65fd7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.core/Editor/Utilities/UnityPackageInstaller.cs
+++ b/com.onesignal.unity.core/Editor/Utilities/UnityPackageInstaller.cs
@@ -1,0 +1,58 @@
+/*
+* Modified MIT License
+* 
+* Copyright 2022 OneSignal
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* 
+* 1. The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+* 
+* 2. All copies of substantial portions of the Software may only be used in connection
+* with services provided by OneSignal.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+/// <summary>
+/// Helper to download and install packages
+/// </summary>
+public static class UnityPackageInstaller {
+    /// <summary>
+    /// Downloads and install a unitypackage from the specified url
+    /// </summary>
+    public static void DownloadAndInstall(string url, string progressMessage, Action<bool> onComplete) {
+        var request = EditorWebRequest.Get(url);
+        request.AddEditorProgressDialog(progressMessage);
+        request.Send(unityRequest => {
+            if (unityRequest.error != null) {
+                EditorUtility.DisplayDialog("Package Download failed.", unityRequest.error, "Ok");
+                onComplete(false);
+            }
+
+            var projectPath    = Application.dataPath.Substring(0, Application.dataPath.Length - 6);
+            var tmpPackageFile = projectPath + FileUtil.GetUniqueTempPathInProject() + ".unityPackage";
+
+            File.WriteAllBytes(tmpPackageFile, unityRequest.downloadHandler.data);
+            AssetDatabase.ImportPackage(tmpPackageFile, false);
+
+            onComplete(true);
+        });
+    }
+}

--- a/com.onesignal.unity.core/Editor/Utilities/UnityPackageInstaller.cs.meta
+++ b/com.onesignal.unity.core/Editor/Utilities/UnityPackageInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 411c1d92254569445a0f46eadd10d117
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
To make it easier to update from 2.x to 3.x (as well as any future releases)

### Added
- Included a new setup step from the OneSignal Unity Editor menu (**Window > OneSignal**) which syncs the example code bundle with the core package version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/434)
<!-- Reviewable:end -->
