### PR TITLE
[FIX] Initialized SDK twice if before RuntimeInitializeOnLoadMethod

### DIFF
--- a/OneSignalExample/Assets/OneSignal/Attribution/VspAttribution.cs
+++ b/OneSignalExample/Assets/OneSignal/Attribution/VspAttribution.cs
@@ -93,10 +93,15 @@ namespace OneSignalSDK
 				return AnalyticsResult.AnalyticsDisabled;
 			}
 		}
+		
 #if ONE_SIGNAL_INSTALLED
-		[RuntimeInitializeOnLoadMethod]
-		public static void AttachToInit()
-			=> OneSignal.OnInitialize += appId => SendAttributionEvent("Login", "OneSignal", appId);
+		[RuntimeInitializeOnLoadMethod] 
+		public static void AttachToInit() {
+			if (string.IsNullOrEmpty(OneSignal.AppId))
+				OneSignal.OnInitialize += appId => SendAttributionEvent("Login", "OneSignal", appId);
+			else
+				SendAttributionEvent("Login", "OneSignal", OneSignal.AppId);
+		}
 #endif
 	}
 }

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NotificationPermission` return from native SDK no longer raises a casting exception on iOS
 - Resolved infinite loops on logging initialization conditions
 - iOS postprocessing will respect existing entitlement files
+- Will no longer init SDK again if done before `RuntimeInitializeOnLoadMethod`
 
 ## [3.0.0-beta.3]
 ### Fixed

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroidInit.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroidInit.cs
@@ -33,7 +33,10 @@ namespace OneSignalSDK {
     /// 
     /// </summary>
     internal static class OneSignalAndroidInit {
-        [RuntimeInitializeOnLoadMethod] public static void Init() => OneSignal.Default = new OneSignalAndroid();
+        [RuntimeInitializeOnLoadMethod] public static void Init() {
+            if (string.IsNullOrEmpty(OneSignal.AppId))
+                OneSignal.Default = new OneSignalAndroid();
+        }
     }
 }
 #endif

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroidInit.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroidInit.cs
@@ -34,7 +34,7 @@ namespace OneSignalSDK {
     /// </summary>
     internal static class OneSignalAndroidInit {
         [RuntimeInitializeOnLoadMethod] public static void Init() {
-            if (string.IsNullOrEmpty(OneSignal.AppId))
+            if (!OneSignal.DidInitialize) 
                 OneSignal.Default = new OneSignalAndroid();
         }
     }

--- a/com.onesignal.unity.core/Runtime/OneSignal.Internal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.Internal.cs
@@ -32,10 +32,12 @@ using UnityEngine;
 namespace OneSignalSDK {
     public abstract partial class OneSignal {
         internal static string AppId { get; private set; }
+        internal static bool DidInitialize { get; private set; }
         internal static event Action<string> OnInitialize;
 
         protected static void _completedInit(string appId) {
-            AppId = appId;
+            AppId         = appId;
+            DidInitialize = true;
             OnInitialize?.Invoke(AppId);
         }
         

--- a/com.onesignal.unity.core/Runtime/OneSignal.Internal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.Internal.cs
@@ -31,8 +31,13 @@ using UnityEngine;
 
 namespace OneSignalSDK {
     public abstract partial class OneSignal {
+        internal static string AppId { get; private set; }
         internal static event Action<string> OnInitialize;
-        protected static void _completedInit(string appId) => OnInitialize?.Invoke(appId);
+
+        protected static void _completedInit(string appId) {
+            AppId = appId;
+            OnInitialize?.Invoke(AppId);
+        }
         
         protected LogLevel _logLevel = LogLevel.Fatal;
         protected LogLevel _alertLevel = LogLevel.None;

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOSInit.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOSInit.cs
@@ -33,7 +33,10 @@ namespace OneSignalSDK {
     /// 
     /// </summary>
     internal static class OneSignalIOSInit {
-        [RuntimeInitializeOnLoadMethod] public static void Init() => OneSignal.Default = new OneSignalIOS();
+        [RuntimeInitializeOnLoadMethod] public static void Init() {
+            if (string.IsNullOrEmpty(OneSignal.AppId))
+                OneSignal.Default = new OneSignalIOS();
+        }
     }
 }
 #endif

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOSInit.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOSInit.cs
@@ -34,7 +34,7 @@ namespace OneSignalSDK {
     /// </summary>
     internal static class OneSignalIOSInit {
         [RuntimeInitializeOnLoadMethod] public static void Init() {
-            if (string.IsNullOrEmpty(OneSignal.AppId))
+            if (!OneSignal.DidInitialize) 
                 OneSignal.Default = new OneSignalIOS();
         }
     }


### PR DESCRIPTION
### Fixed
- Will no longer init SDK again if done before `RuntimeInitializeOnLoadMethod`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/437)
<!-- Reviewable:end -->
