### PR TITLE
[FEATURE] Freeze to latest platform SDKs

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Default export path for notification icons on Android changed to `Assets/Plugins/Android/res`
+- Froze imported OneSignal iOS SDK to [3.10.0](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.10.0) release
+- Froze imported OneSignal Android SDK to [4.6.5](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.6.5) release
 ### Removed
 - Legacy AndroidManifest from past version of imported OneSignal Android SDK
 - Legacy Android notification icons

--- a/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
+++ b/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
@@ -3,6 +3,6 @@
     <repositories>
       <repository>https://repo.maven.apache.org/maven2</repository>
     </repositories>
-    <androidPackage spec="com.onesignal:OneSignal:[4.6.2, 4.6.99[" />
+    <androidPackage spec="com.onesignal:OneSignal:4.6.5" />
   </androidPackages>
 </dependencies>

--- a/com.onesignal.unity.ios/Editor/OneSignalIOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignalIOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-        <iosPod name="OneSignalXCFramework" version="~> 3.8.1"  addToAllTargets="true" />
+        <iosPod name="OneSignalXCFramework" version="3.10.0"  addToAllTargets="true" />
     </iosPods>
 </dependencies>


### PR DESCRIPTION
### Changed
- Froze imported OneSignal iOS SDK to [3.10.0](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.10.0) release
- Froze imported OneSignal Android SDK to [4.6.5](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.6.5) release

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/439)
<!-- Reviewable:end -->
