### PR TITLE
[IMPROVEMENT] Additional example logging around RequiresPrivacyConsent

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Log an error in the example app when `RequiresPrivacyConsent` is attempted to be set to false from true
 
 ## [3.0.0-beta.5]
 ### Changed

--- a/OneSignalExample/Assets/OneSignal/Example/OneSignalExampleBehaviour.cs
+++ b/OneSignalExample/Assets/OneSignal/Example/OneSignalExampleBehaviour.cs
@@ -189,7 +189,7 @@ public class OneSignalExampleBehaviour : MonoBehaviour {
 
     public void ToggleRequiresPrivacyConsent() {        
         if (OneSignal.Default.RequiresPrivacyConsent)
-            _log($"Cannot toggle RequiresPrivacyConsent from TRUE to FALSE");
+            _error($"Cannot toggle RequiresPrivacyConsent from TRUE to FALSE");
         else {
             _log($"Toggling RequiresPrivacyConsent to <b>{!OneSignal.Default.RequiresPrivacyConsent}</b>");
             OneSignal.Default.RequiresPrivacyConsent = !OneSignal.Default.RequiresPrivacyConsent;

--- a/OneSignalExample/Assets/OneSignal/Example/OneSignalExampleBehaviour.cs
+++ b/OneSignalExample/Assets/OneSignal/Example/OneSignalExampleBehaviour.cs
@@ -187,9 +187,13 @@ public class OneSignalExampleBehaviour : MonoBehaviour {
         OneSignal.Default.Initialize(appId);
     }
 
-    public void ToggleRequiresPrivacyConsent() {
-        _log($"Toggling RequiresPrivacyConsent to <b>{!OneSignal.Default.RequiresPrivacyConsent}</b>");
-        OneSignal.Default.RequiresPrivacyConsent = !OneSignal.Default.RequiresPrivacyConsent;
+    public void ToggleRequiresPrivacyConsent() {        
+        if (OneSignal.Default.RequiresPrivacyConsent)
+            _log($"Cannot toggle RequiresPrivacyConsent from TRUE to FALSE");
+        else {
+            _log($"Toggling RequiresPrivacyConsent to <b>{!OneSignal.Default.RequiresPrivacyConsent}</b>");
+            OneSignal.Default.RequiresPrivacyConsent = !OneSignal.Default.RequiresPrivacyConsent;
+        }
     }
 
     public void TogglePrivacyConsent() {


### PR DESCRIPTION
### Changed
- Log an error in the example app when `RequiresPrivacyConsent` is attempted to be set to false from true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/443)
<!-- Reviewable:end -->
