### PR TITLE
[FIX] Service extension pod dependency wrong version

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- iOS build post processor will determine extension's imported OneSignalXCFramework from the package's dependencies xml
 
 ## [3.0.0-beta.5]
 ### Changed

--- a/com.onesignal.unity.ios/Editor/OneSignalIOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignalIOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-        <iosPod name="OneSignalXCFramework" version="3.10.0"  addToAllTargets="true" />
+        <iosPod name="OneSignalXCFramework" version="3.10.0" addToAllTargets="true" />
     </iosPods>
 </dependencies>


### PR DESCRIPTION
### Fixed
- iOS build post processor will determine extension's imported OneSignalXCFramework from the package's dependencies xml