### PR TITLE
Add issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -36,16 +36,15 @@ body:
       value: 2021.2.12 (latest)
     validations:
       required: true
-  - type: checkboxes
+  - type: dropdown
     id: platform
     attributes:
       label: Platform
       description: Which platform are you having an issue with?
+      multiple: true
       options:
-        - label: iOS
-          required: false
-        - label: Android
-          required: false
+        - iOS
+        - Android
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -57,6 +57,7 @@ body:
       options:
         - iOS
         - Android
+        - Other
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -55,3 +55,11 @@ body:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
       render: Shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/OneSignal/OneSignal-Unity-SDK/blob/a5a2db49604e9b6386fb46c7869db9d7f814702d/CONTRIBUTING.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -35,8 +35,7 @@ body:
     attributes:
       label: What did you expect to happen?
       description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
-      value: "A bug happened!"
+      placeholder: I expected the app to continue running no matter how many times I tap the screen.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -27,16 +27,13 @@ body:
       value: "A bug happened!"
     validations:
       required: true
-  - type: dropdown
+  - type: textarea
     id: unity-version
     attributes:
       label: Unity version
       description: What version of Unity are you running?
-      options:
-        - Unity 2021.2.12 (latest)
-        - Unity 2021.x
-        - Unity 2020.x
-        - Unity 2019.x
+      placeholder: 2021.2.x
+      value: 2021.2.12 (latest)
     validations:
       required: true
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+# assignees:
+#   - onesignal/unity
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what steps are required to reproduce.
+      placeholder: Tell us what's going on.
+      value: "Something isn't quite right!"
+    validations:
+      required: true
+  - type: textarea
+    id: what-are-expectations
+    attributes:
+      label: What did you expect to happen?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: dropdown
+    id: unity-version
+    attributes:
+      label: Unity version
+      description: What version of Unity are you running?
+      options:
+        - Unity 2021.2.12 (latest)
+        - Unity 2021.x
+        - Unity 2020.x
+        - Unity 2019.x
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: Which platform are you having an issue with?
+      options:
+        - iOS
+        - Android
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: Shell

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -47,6 +47,15 @@ body:
       value: 2021.2.12 (latest)
     validations:
       required: true
+  - type: textarea
+    id: unity-sdk-version
+    attributes:
+      label: Unity SDK version
+      description: The version of the OneSignal Unity SDK used in your app.
+      placeholder: 3.0.0-beta.6 Release
+      value: 2.14.6
+    validations:
+      required: true
   - type: dropdown
     id: platform
     attributes:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -53,7 +53,6 @@ body:
       label: OneSignal Unity SDK version
       description: The version of the OneSignal Unity SDK used in your app.
       placeholder: 3.0.0-beta.6 Release
-      value: 2.14.6
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -50,7 +50,7 @@ body:
   - type: textarea
     id: unity-sdk-version
     attributes:
-      label: Unity SDK version
+      label: OneSignal Unity SDK version
       description: The version of the OneSignal Unity SDK used in your app.
       placeholder: 3.0.0-beta.6 Release
       value: 2.14.6

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -39,16 +39,16 @@ body:
         - Unity 2019.x
     validations:
       required: true
-  - type: dropdown
+  - type: checkboxes
     id: platform
     attributes:
       label: Platform
       description: Which platform are you having an issue with?
       options:
-        - iOS
-        - Android
-    validations:
-      required: true
+        - label: iOS
+          required: false
+        - label: Android
+          required: false
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -13,9 +13,21 @@ body:
     id: what-happened
     attributes:
       label: What happened?
-      description: Also tell us, what steps are required to reproduce.
-      placeholder: Tell us what's going on.
-      value: "Something isn't quite right!"
+      description: Provide a thorough description of whats going on.
+      placeholder: The latest version of the SDK causes my screen to go blank when I tap on the screen three times.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce?
+      description: Provide as much detail as posible to reproduce the issue.
+      placeholder: |
+        1. Install vX.Y.Z of dependency
+        2. Launch the app on iOS device
+        3. Tap the screen three times
+        4. Note that the app crashes
+      render: Markdown
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
This PR adds an issue template form to collect info needed to triage bug reports.

The form asks the following questions;
1. What happened?
2. What did you expect to happen?
3. What version of Unity are you running?
4. Which platform are you having an issue with?
5. Relevant log output
6. Code of conduct

If there are any other questions I should ask, feel free to drop a comment so I can incorporate the changes. Some things I'm not sure about are
1.  Which versions of Unity do we want to include in the dropdown?
2. Do we want to ask for specific version of iOS/Android
3. Should we ask which libraries are being used 

**[📝 Rendered form](https://github.com/OneSignal/OneSignal-Unity-SDK/blob/484a65715435392e77cf5c7642e65940a83778ab/.github/ISSUE_TEMPLATE/BUG_REPORT.yml)**

### Resources

###### References
* [Creating issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms)
* [Creating issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-templates)
* [Configuring the template chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/454)
<!-- Reviewable:end -->
