### PR TITLE
[IMPROVEMENT] Add podfile amendments to Append builds

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Checks for VERSION file before attempting to read it
+- Added podfile amendments to iOS Append builds
 
 ## [3.0.0-beta.6]
 ### Fixed

--- a/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
+++ b/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
@@ -166,8 +166,10 @@ namespace OneSignalSDK {
             // If file exists then the below has been completed before from another build
             // The below will not be updated on Append builds
             // Changes would most likely need to be made to support Append builds
-            if (ExtensionCreatePlist(_outputPath))
+            if (ExtensionCreatePlist(_outputPath)) {
+                ExtensionAddPodsToTarget();
                 return;
+            }
 
             var extensionGuid = _project.AddAppExtension(_project.GetMainTargetGuid(),
                 ServiceExtensionTargetName,


### PR DESCRIPTION
### Changed
- Added podfile amendments to iOS Append builds. Previously, EDM4U generated a new podfile on Append builds and broke the OneSignal native extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/455)
<!-- Reviewable:end -->
