### PR TITLE
Fix namespaces for tool copies in project package

### DIFF
--- a/OneSignalExample/Assets/OneSignal/Editor/PackageManagement/Manifest.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/PackageManagement/Manifest.cs
@@ -27,6 +27,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using OneSignalSDK.Installer;
 
 namespace OneSignalSDK {
     /// <summary>

--- a/OneSignalExample/Assets/OneSignal/Editor/Setup/OneSignalSetupWindow.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/Setup/OneSignalSetupWindow.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Collections.Generic;
+using OneSignalSDK.Installer;
 using UnityEditor;
 using UnityEngine;
 

--- a/OneSignalExample/Assets/OneSignal/Editor/Utilities/MiniJSON.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/Utilities/MiniJSON.cs
@@ -33,7 +33,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
-namespace OneSignalSDK {
+namespace OneSignalSDK.Installer {
     // Forked from  https://github.com/Jackyjjc/MiniJSON.cs
     // version: 6de00beb134bbab9d873033a48b32e4067ed0c25
 

--- a/OneSignalExample/Assets/OneSignal/Editor/Utilities/ReflectionHelpers.cs
+++ b/OneSignalExample/Assets/OneSignal/Editor/Utilities/ReflectionHelpers.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace OneSignalSDK {
+namespace OneSignalSDK.Installer {
     public static class ReflectionHelpers {
         public static IEnumerable<Type> FindAllAssignableTypes<T>(string assemblyFilter) {
             var assignableType = typeof(T);


### PR DESCRIPTION
Fix for error that didn't show up in https://github.com/OneSignal/OneSignal-Unity-SDK/pull/456

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/458)
<!-- Reviewable:end -->
