### PR TITLE
[FIX] Removed code unsupported in Unity 2018

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Checks for VERSION file before attempting to read it
 - Added podfile amendments to iOS Append builds
 - Include utilities necessary for independent use of the initial unitypackage install
+- Removed unused helper method in the iOS post processor which used code from after Unity 2018
 
 ## [3.0.0-beta.6]
 ### Fixed

--- a/com.onesignal.unity.ios/Editor/PBXProjectExtensions.cs
+++ b/com.onesignal.unity.ios/Editor/PBXProjectExtensions.cs
@@ -35,18 +35,12 @@ namespace OneSignalSDK {
 
         public static string GetMainTargetGuid(this PBXProject project)
             => project.GetUnityMainTargetGuid();
-
-        public static string GetFrameworkGuid(this PBXProject project)
-            => project.GetUnityFrameworkTargetGuid();
     #else
         public static string GetMainTargetName(this PBXProject project) 
             => PBXProject.GetUnityTargetName();
          
         public static string GetMainTargetGuid(this PBXProject project)
              => project.TargetGuidByName(PBXProject.GetUnityTargetName());
-
-        public static string GetFrameworkGuid(this PBXProject project)
-             => GetPBXProjectTargetGuid(project);
     #endif
     }
 }


### PR DESCRIPTION
### Fixed
- Removed unused helper method in the iOS post processor which used code from after Unity 2018

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/463)
<!-- Reviewable:end -->
