### PR TITLE
[FIX] Missing RemoveExternalUserId

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added value to additionalData on Android for NotificationOpened
 - Reverted [#430](https://github.com/OneSignal/OneSignal-Unity-SDK/pull/430) due to a deprecation of where Android resources can be stored in Unity. Notification icons to be changed for Android can again be found at `Assets/Plugins/Android/OneSignalConfig.plugin`.
 - Updated example code for PostNotification to show an example that works without the API key
+- Reimplented support for `RemoveExternalUserId`
 
 ## [3.0.0]
 ### Changed

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added value to additionalData on Android for NotificationOpened
 - Reverted [#430](https://github.com/OneSignal/OneSignal-Unity-SDK/pull/430) due to a deprecation of where Android resources can be stored in Unity. Notification icons to be changed for Android can again be found at `Assets/Plugins/Android/OneSignalConfig.plugin`.
 - Updated example code for PostNotification to show an example that works without the API key
-- Reimplented support for `RemoveExternalUserId`
+- Reimplemented support for `RemoveExternalUserId`
 
 ## [3.0.0]
 ### Changed

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
@@ -221,6 +221,12 @@ namespace OneSignalSDK {
             return await proxy;
         }
 
+        public override async Task<bool> RemoveExternalUserId() {
+            var proxy = new OSExternalUserIdUpdateCompletionHandler();
+            _sdkClass.CallStatic("removeExternalUserId", proxy);
+            return await proxy;
+        }
+
         public override async Task<bool> LogOutEmail() {
             var proxy = new EmailUpdateHandler();
             _sdkClass.CallStatic("logoutEmail", proxy);

--- a/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
+++ b/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
@@ -139,6 +139,10 @@ namespace OneSignalSDK {
             return Task.FromResult(false);
         }
 
+        public override Task<bool> RemoveExternalUserId() {
+            return Task.FromResult(false);
+        }
+
         public override Task<bool> LogOutEmail() {
             return Task.FromResult(false);
         }

--- a/com.onesignal.unity.core/Runtime/OneSignal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.cs
@@ -325,6 +325,12 @@ namespace OneSignalSDK {
         public abstract Task<bool> SetSMSNumber(string smsNumber, string authHash = null);
 
         /// <summary>
+        /// Removes the current external user id from each known subscription
+        /// </summary>
+        /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
+        public abstract Task<bool> RemoveExternalUserId();
+
+        /// <summary>
         /// If this user logs out of your app and/or you would like to disassociate their email with the current
         /// OneSignal user
         /// </summary>

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.Interface.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.Interface.cs
@@ -81,6 +81,7 @@ namespace OneSignalSDK {
         [DllImport("__Internal")] private static extern void _setEmail(string email, string authHash, int hashCode, BooleanResponseDelegate callback);
         [DllImport("__Internal")] private static extern void _setSMSNumber(string smsNumber, string authHash, int hashCode, BooleanResponseDelegate callback);
 
+        [DllImport("__Internal")] private static extern void _removeExternalUserId(int hashCode, BooleanResponseDelegate callback);
         [DllImport("__Internal")] private static extern void _logoutEmail(int hashCode, BooleanResponseDelegate callback);
         [DllImport("__Internal")] private static extern void _logoutSMSNumber(int hashCode, BooleanResponseDelegate callback);
         

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
@@ -184,6 +184,12 @@ namespace OneSignalSDK {
             return await proxy;
         }
 
+        public override async Task<bool> RemoveExternalUserId() {
+            var (proxy, hashCode) = _setupProxy<bool>();
+            _removeExternalUserId(hashCode, BooleanCallbackProxy);
+            return await proxy;
+        }
+
         public override async Task<bool> LogOutEmail() {
             var (proxy, hashCode) = _setupProxy<bool>();
             _logoutEmail(hashCode, BooleanCallbackProxy);

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridge.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridge.mm
@@ -373,6 +373,11 @@ void _setSMSNumber(const char* smsNumber, const char* authHash, int hashCode, Bo
                 withFailure:^(NSError *error) { CALLBACK(NO); }];
 }
 
+void _removeExternalUserId(int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal removeExternalUserId:^(NSDictionary *results) { CALLBACK(YES); }
+                        withFailure:^(NSError *error) { CALLBACK(NO); }];
+}
+
 void _logoutEmail(int hashCode, BooleanResponseDelegate callback) {
     [OneSignal logoutEmailWithSuccess:^{ CALLBACK(YES); }
                           withFailure:^(NSError *error) { CALLBACK(NO); }];
@@ -380,18 +385,18 @@ void _logoutEmail(int hashCode, BooleanResponseDelegate callback) {
 
 void _logoutSMSNumber(int hashCode, BooleanResponseDelegate callback) {
     [OneSignal logoutSMSNumberWithSuccess:^(NSDictionary *results) { CALLBACK(YES); }
-                                  withFailure:^(NSError *error) { CALLBACK(NO); }];
-    }
+                              withFailure:^(NSError *error) { CALLBACK(NO); }];
+}
     
-    void _setLanguage(const char* languageCode, int hashCode, BooleanResponseDelegate callback) {
-        [OneSignal setLanguage:TO_NSSTRING(languageCode)
-                   withSuccess:^{ CALLBACK(YES); }
-                   withFailure:^(NSError *error) { CALLBACK(NO); }];
-    }
+void _setLanguage(const char* languageCode, int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal setLanguage:TO_NSSTRING(languageCode)
+               withSuccess:^{ CALLBACK(YES); }
+               withFailure:^(NSError *error) { CALLBACK(NO); }];
+}
 
-    void _promptLocation() {
-        [OneSignal promptLocation];
-    }
+void _promptLocation() {
+    [OneSignal promptLocation];
+}
 
 void _setShareLocation(bool share) {
     [OneSignal setLocationShared:share];


### PR DESCRIPTION
### Fixed
- Reimplemented support for `RemoveExternalUserId`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/475)
<!-- Reviewable:end -->
