### PR TITLE
[FIX] Notification serialization on iOS

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated example code for PostNotification to show an example that works without the API key
 - Reimplemented support for `RemoveExternalUserId`
 - Reimplemented `disablePush` as `PushEnabled`
+- iOS serialization of `Notification` type now accounts for `additionalData` and `rawPayload` in all cases
 
 ## [3.0.0]
 ### Changed

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.Mappings.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.Mappings.cs
@@ -26,6 +26,8 @@
  */
 
 using System;
+using System.Collections.Generic;
+using UnityEngine;
 
 namespace OneSignalSDK {
     public sealed partial class OneSignalIOS : OneSignal {
@@ -75,6 +77,17 @@ namespace OneSignalSDK {
 
             public static implicit operator NotificationPermission(NotificationPermissionState source)
                 => (NotificationPermission)source.status;
+        }
+
+        private static void _fillNotifFromObj(ref Notification notif, object notifObj) {
+            if (!(notifObj is Dictionary<string, object> notifDict)) 
+                return;
+            
+            if (notifDict.ContainsKey("additionalData"))
+                notif.additionalData = notifDict["additionalData"] as Dictionary<string, object>;
+            
+            if (notifDict.ContainsKey("rawPayload") && notifDict["rawPayload"] is Dictionary<string, object> payloadDict)
+                notif.rawPayload = Json.Serialize(payloadDict);
         }
     }
 }


### PR DESCRIPTION
### Fixed
- iOS serialization of `Notification` type now accounts for `additionalData` and `rawPayload` in all cases

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/477)
<!-- Reviewable:end -->
