### PR TITLE
[FEATURE] InAppMessageAction docs and idiomatic fields

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Added support for OneSignal iOS functionality `setLaunchURLsInApp`
 - Improved included [README](../../../com.onesignal.unity.android/Editor/OneSignalConfig.plugin/README.md) for changing the notification icons in the Android plugin.
+- Added inline documentiation and Unity idiomatic fields to the `InAppMessageAction`
 ### Fixed
 - Added value to actionId for Android
 - Added value to additionalData on Android for NotificationOpened

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Added support for OneSignal iOS functionality `setLaunchURLsInApp`
 - Improved included [README](../../../com.onesignal.unity.android/Editor/OneSignalConfig.plugin/README.md) for changing the notification icons in the Android plugin.
-- Added inline documentiation and Unity idiomatic fields to the `InAppMessageAction`
+- Added inline documentation and Unity idiomatic fields to the `InAppMessageAction`
 ### Fixed
 - Added value to actionId for Android
 - Added value to additionalData on Android for NotificationOpened

--- a/com.onesignal.unity.core/Runtime/Models/InAppMessageAction.cs
+++ b/com.onesignal.unity.core/Runtime/Models/InAppMessageAction.cs
@@ -26,12 +26,33 @@
  */
 
 using System;
+using UnityEngine;
 
 namespace OneSignalSDK {
-    [Serializable] public sealed class InAppMessageAction {
+    [Serializable] public sealed class InAppMessageAction : ISerializationCallbackReceiver {
+        public string clickName;
+        public string clickUrl;
+        public bool firstClick;
+        public bool closesMessage;
+
+    #region Native Field Handling
         public string click_name;
         public string click_url;
         public bool first_click;
         public bool closes_message;
+
+        public void OnBeforeSerialize() {
+            // no operation
+        }
+
+        public void OnAfterDeserialize() {
+            SDKDebug.Info("DESERIALIZING IAM ACTION");
+            clickName     = click_name;
+            clickUrl      = click_url;
+            firstClick    = first_click;
+            closesMessage = closes_message;
+        }
+    #endregion
+
     }
 }

--- a/com.onesignal.unity.core/Runtime/Models/InAppMessageAction.cs
+++ b/com.onesignal.unity.core/Runtime/Models/InAppMessageAction.cs
@@ -54,10 +54,10 @@ namespace OneSignalSDK {
         public bool closesMessage;
 
     #region Native Field Handling
-        public string click_name;
-        public string click_url;
-        public bool first_click;
-        public bool closes_message;
+        [Obsolete("Use clickName")] public string click_name;
+        [Obsolete("Use clickUrl")] public string click_url;
+        [Obsolete("Use firstClick")] public bool first_click;
+        [Obsolete("Use closesMessage")] public bool closes_message;
 
         public void OnBeforeSerialize() {
             // no operation
@@ -65,10 +65,12 @@ namespace OneSignalSDK {
 
         public void OnAfterDeserialize() {
             SDKDebug.Info("DESERIALIZING IAM ACTION");
+            #pragma warning disable CS0618
             clickName     = click_name;
             clickUrl      = click_url;
             firstClick    = first_click;
             closesMessage = closes_message;
+            #pragma warning restore CS0618
         }
     #endregion
 

--- a/com.onesignal.unity.core/Runtime/Models/InAppMessageAction.cs
+++ b/com.onesignal.unity.core/Runtime/Models/InAppMessageAction.cs
@@ -29,10 +29,28 @@ using System;
 using UnityEngine;
 
 namespace OneSignalSDK {
+    /// <summary>
+    /// Action associated with clicking a button in an In-App Message
+    /// </summary>
     [Serializable] public sealed class InAppMessageAction : ISerializationCallbackReceiver {
+        /// <summary>
+        /// An optional click name defined for the action element
+        /// </summary>
         public string clickName;
+
+        /// <summary>
+        /// An optional URL that opens when the action takes place
+        /// </summary>
         public string clickUrl;
+
+        /// <summary>
+        /// Whether this is the first time the user has clicked any action on the In-App Message
+        /// </summary>
         public bool firstClick;
+
+        /// <summary>
+        /// Whether this action will close the In-App Message
+        /// </summary>
         public bool closesMessage;
 
     #region Native Field Handling


### PR DESCRIPTION
### Changed
- Added inline documentation and Unity idiomatic fields to the `InAppMessageAction`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/479)
<!-- Reviewable:end -->
