### PR TITLE
[FIX] NSExtensionPrincipalClass value

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iOS serialization of `Notification` type now accounts for `additionalData` and `rawPayload` in all cases
 - iOS notifications opened from cold start will be received via `NotificationOpened`
 - Added missing Notification fields
+- Added prefix to the NSExtensionPrincipalClass in the NotificationServiceExtension Info.plist
 
 ## [3.0.0]
 ### Changed

--- a/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
+++ b/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
@@ -234,7 +234,10 @@ namespace OneSignalSDK {
             notificationServicePlist.ReadFromFile(Path.Combine(PluginFilesPath, "Info.plist"));
             notificationServicePlist.root.SetString("CFBundleShortVersionString", PlayerSettings.bundleVersion);
             notificationServicePlist.root.SetString("CFBundleVersion", PlayerSettings.iOS.buildNumber);
-            
+
+            string NSExtensionPrincipalClass = notificationServicePlist.root["NSExtension"]["NSExtensionPrincipalClass"].AsString();
+            notificationServicePlist.root["NSExtension"].AsDict().SetString("NSExtensionPrincipalClass", "$(PRODUCT_MODULE_NAME)." + NSExtensionPrincipalClass);
+
             notificationServicePlist.WriteToFile(plistPath);
             
             return alreadyExists;

--- a/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
+++ b/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
@@ -235,9 +235,6 @@ namespace OneSignalSDK {
             notificationServicePlist.root.SetString("CFBundleShortVersionString", PlayerSettings.bundleVersion);
             notificationServicePlist.root.SetString("CFBundleVersion", PlayerSettings.iOS.buildNumber);
 
-            string NSExtensionPrincipalClass = notificationServicePlist.root["NSExtension"]["NSExtensionPrincipalClass"].AsString();
-            notificationServicePlist.root["NSExtension"].AsDict().SetString("NSExtensionPrincipalClass", "$(PRODUCT_MODULE_NAME)." + NSExtensionPrincipalClass);
-
             notificationServicePlist.WriteToFile(plistPath);
             
             return alreadyExists;

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/Info.plist
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/Info.plist
@@ -25,7 +25,7 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.usernotifications.service</string>
 		<key>NSExtensionPrincipalClass</key>
-		<string>NotificationService</string>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
### Fixed
- Added prefix to the NSExtensionPrincipalClass in the NotificationServiceExtension Info.plist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/483)
<!-- Reviewable:end -->
