### PR TITLE
[CHANGE] Overwrite project's AndroidManifest if diff

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Updated included Android SDK to [4.7.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.7.1)
-- Explicitly check for a diff and handle overwrites for the `AndroidManifest.xml` in the project's `OneSignalConfig.plugin` and the package's
+- Explicitly check for a diff and handle overwrites for the `AndroidManifest.xml` between the project's and package's `OneSignalConfig.plugin`
 
 ## [3.0.1]
 ### Added

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Updated included Android SDK to [4.7.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.7.1)
+- Explicitly check for a diff and handle overwrites for the `AndroidManifest.xml` in the project's `OneSignalConfig.plugin` and the package's
 
 ## [3.0.1]
 ### Added

--- a/com.onesignal.unity.android/Editor/SetupSteps/ExportAndroidResourcesStep.cs
+++ b/com.onesignal.unity.android/Editor/SetupSteps/ExportAndroidResourcesStep.cs
@@ -82,12 +82,11 @@ namespace OneSignalSDK {
 
                 if (!Directory.Exists(containingPath))
                     Directory.CreateDirectory(containingPath);
-
-                // don't copy over existing png files
-                if (fileExportPath.Contains(".png") && !File.Exists(fileExportPath))
-                    File.Copy(file, fileExportPath);
-                else // all other files should be refreshed
+                
+                if (!fileExportPath.Contains(".png")) // always refresh non-pngs
                     File.Copy(file, fileExportPath, true);
+                else if (!File.Exists(fileExportPath)) // don't copy over existing png files
+                    File.Copy(file, fileExportPath);
             }
 
             AssetDatabase.Refresh();

--- a/com.onesignal.unity.android/Editor/SetupSteps/ExportAndroidResourcesStep.cs
+++ b/com.onesignal.unity.android/Editor/SetupSteps/ExportAndroidResourcesStep.cs
@@ -83,8 +83,11 @@ namespace OneSignalSDK {
                 if (!Directory.Exists(containingPath))
                     Directory.CreateDirectory(containingPath);
 
-                if (!File.Exists(fileExportPath))
+                // don't copy over existing png files
+                if (fileExportPath.Contains(".png") && !File.Exists(fileExportPath))
                     File.Copy(file, fileExportPath);
+                else // all other files should be refreshed
+                    File.Copy(file, fileExportPath, true);
             }
 
             AssetDatabase.Refresh();

--- a/com.onesignal.unity.android/Editor/SetupSteps/ExportAndroidResourcesStep.cs
+++ b/com.onesignal.unity.android/Editor/SetupSteps/ExportAndroidResourcesStep.cs
@@ -56,7 +56,13 @@ namespace OneSignalSDK {
 
             var fileDiff = packagePaths.Except(exportPaths);
 
-            return !fileDiff.Any();
+            if (fileDiff.Any())
+                return false;
+
+            var pluginManifest = File.ReadAllText(_manifestPackagePath);
+            var projectManifest = File.ReadAllText(_manifestExportPath);
+            
+            return pluginManifest == projectManifest;
         }
 
         protected override void _runStep() {
@@ -87,7 +93,11 @@ namespace OneSignalSDK {
         private const string _pluginName = "OneSignalConfig.plugin";
         private static readonly string _packagePath = Path.Combine("Packages", "com.onesignal.unity.android", "Editor");
         private static readonly string _androidPluginsPath = Path.Combine("Assets", "Plugins", "Android");
+        
         private static readonly string _pluginPackagePath = Path.Combine(_packagePath, _pluginName);
         private static readonly string _pluginExportPath = Path.Combine(_androidPluginsPath, _pluginName);
+        
+        private static readonly string _manifestPackagePath = Path.Combine(_pluginPackagePath, "AndroidManifest.xml");
+        private static readonly string _manifestExportPath = Path.Combine(_pluginExportPath, "AndroidManifest.xml");
     }
 }


### PR DESCRIPTION
### Changed
- Explicitly check for a diff and handle overwrites for the `AndroidManifest.xml` between the project's and package's `OneSignalConfig.plugin`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/488)
<!-- Reviewable:end -->
