### PR TITLE
[FIX] Unity Build on Windows Targeting iOS errors on Entitlements file

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated included Android SDK to [4.7.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.7.1)
 - Explicitly check for a diff and handle overwrites for the `AndroidManifest.xml` between the project's and package's `OneSignalConfig.plugin`
+### Fixed
+- iOS builds on Unity on Windows failing on Entitlements file path. Fixes [#491](https://github.com/OneSignal/OneSignal-Unity-SDK/issues/442)
 
 ## [3.0.1]
 ### Added
@@ -128,7 +130,7 @@ If you run into any problems, please don’t hesitate to [open an issue](https:/
 
 ## [2.14.1]
 ### Fixed
-- Corrected directory separators in post processor when building for iOS in a 
+- Corrected directory separators in post processor when building for iOS in a
   Windows environment. From PR [#376](https://github.com/OneSignal/OneSignal-Unity-SDK/pull/376)
   by [@SplenectomY](https://github.com/SplenectomY). Fixes [#375](https://github.com/OneSignal/OneSignal-Unity-SDK/issues/375), [#377](https://github.com/OneSignal/OneSignal-Unity-SDK/issues/377), [#380](https://github.com/OneSignal/OneSignal-Unity-SDK/issues/380)
 

--- a/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
+++ b/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
@@ -138,7 +138,7 @@ namespace OneSignalSDK {
             _project.AddFile(relativeDestination, entitlementFileName);
             _project.SetBuildProperty(targetGuid, "CODE_SIGN_ENTITLEMENTS", relativeDestination);
 
-            return entitlementsPath;
+            return relativeDestination;
         }
         
         /// <summary>


### PR DESCRIPTION
### Fixed
* Unity Build on Windows targeting iOS errors on Entitlements file.

### Testing
Was able to reproduce the same issue and stack trace noted in issue #491 and confirm this fixed it.
* Windows 11 with Unity 2020.3.30f1
    - Confirmed project also builds on macOS (with same mac env noted below)
* macOS 12.3.1 with Unity 2020.3.33f1 and Xcode 13.3
* iOS 14.4.1

### Related
Resolves #491

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/493)
<!-- Reviewable:end -->
