### PR TITLE
[Added] Documented CocoaPods 1.11.3 or newer requirement

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,7 +1,9 @@
 # OneSignal Unity SDK 2.x.x to 3.x.x Migration Guide
 
 ## Requirements
-This guide assumes you are upgrading from a 2.x.x version of the OneSignal Unity SDK to the 3.x.x version. Additionally please ensure you are using Unity 2018.4 or newer.
+This guide assumes you are upgrading from a 2.x.x version of the OneSignal Unity SDK to the 3.x.x version. Additionally please ensure you are using:
+* Unity 2018.4 or newer
+* For iOS builds: CocoaPods 1.11.3 or newer
 
 ## Adding 3.x.x to your project
 Follow one of the following sections based on your previous install method of the OneSignal SDK.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ And via many additional platforms. [Check them all out](https://documentation.on
 - A [OneSignal Account](https://app.onesignal.com/signup) if you do not already have one
 - Your OneSignal App ID which you can find under **Settings > Keys & IDs**
 - Unity 2018.4 or newer
+- iOS Builds: CocoaPods 1.11.3 or newer
 - In order to test push notifications you will need
   - An Android 4.0.3 or newer device or emulator with "Google Play services" installed
   - An iOS 9 or newer device (iPhone, iPad, or iPod Touch)


### PR DESCRIPTION
# Description
## One Line Summary
Documented CocoaPods 1.11.3 or newer requirement on both the readme setup and the migration guide.

## Details
### Motivation
This is a required version, otherwise `pod install` runs without any errors but the Xcode project will fail to build with the error "No Such Module 'OneSignal'", as reported in issue #468.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/498)
<!-- Reviewable:end -->
