### PR TITLE
[Fix] iOS publishing error 90206 "contains disallowed file 'Frameworks"

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicitly check for a diff and handle overwrites for the `AndroidManifest.xml` between the project's and package's `OneSignalConfig.plugin`
 - `InstallEdm4uStep` checks for version number to determine if step is completed
 ### Fixed
+- iOS publishing error 90206 when uploading app to Apple.
 - iOS builds on Unity on Windows failing on Entitlements file path. Fixes [#491](https://github.com/OneSignal/OneSignal-Unity-SDK/issues/442)
 - `OneSignalXCFramework` pod version of `OneSignalNotificationServiceExtension` target in Podfile of iOS builds will be upgraded if target is present during post processing
 

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/NotificationService.swift.meta
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/NotificationService.swift.meta
@@ -12,7 +12,7 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
-      Any: 
+      Any:
     second:
       enabled: 0
       settings: {}
@@ -25,13 +25,13 @@ PluginImporter:
   - first:
       iPhone: iOS
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       tvOS: tvOS
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
# Description
## One Line Summary
Omits `NotificationService.swift` from the `UnityFramework` Xcode target to fix an error when publishing the app to Apple.

## Details

### Motivation
This file doesn't need to be on the `UnityFramework` target and doing so means `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` is set to `Yes`. `This causes a STATE_ERROR.VALIDATION_ERROR.90206` error when the app is uploaded to Apple.

Fixes #500

### Scope
Effect Xcode build settings.

# Testing
## Manual testing
### Tested on the following environment
* Xcode 13.3.1
* Unity 2020.3.33f1
* iOS 14.4.1

### What was tested
* iOS device - Ensured the NSE still runs and displayed an image on the notification.
* Upload to Apple is successful
* Ensured `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` is set to `No` on all targets in Xcode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/501)
<!-- Reviewable:end -->
