### PR TITLE
[FEATURE] setLanguage callback for Android

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added support for OneSignal Android `setLanguage` callbacks
+
 ## [3.0.2]
 ### Changed
 - Updated included Android SDK to [4.7.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.7.1)

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.Callbacks.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.Callbacks.cs
@@ -254,6 +254,19 @@ namespace OneSignalSDK {
             }
         }
 
+        private sealed class OSSetLanguageCompletionHandler : OneSignalAwaitableAndroidJavaProxy<bool> {
+            public OSSetLanguageCompletionHandler() : base("OSSetLanguageCompletionHandler") { }
+
+            /// <param name="results">string</param>
+            public void onSuccess(AndroidJavaObject results) => _complete(true);
+
+            /// <param name="error">OSLanguageError</param>
+            public void onFailure(AndroidJavaObject error) {
+                _handleError(error);
+                _complete(false);
+            }
+        }
+
         private sealed class OutcomeCallback : OneSignalAwaitableAndroidJavaProxy<bool> {
             public OutcomeCallback() : base("OutcomeCallback") { }
 

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
@@ -248,8 +248,9 @@ namespace OneSignalSDK {
         }
         
         public override async Task<bool> SetLanguage(string languageCode) {
-            _sdkClass.CallStatic("setLanguage", languageCode);
-            return await Task.FromResult(true); // no callback currently available on Android
+            var proxy = new OSSetLanguageCompletionHandler();
+            _sdkClass.CallStatic("setLanguage", languageCode, proxy);
+            return await proxy;
         }
 
         public override void PromptLocation()


### PR DESCRIPTION
# Description
## One Line Summary
Added support for OneSignal Android `setLanguage` callbacks

## Details

### Motivation
Provides `setLanguage` callback functionality from the native OneSignal Android SDK to the Unity SDK.

## Manual testing
Tested setLanguage call and logged callback in app built with Android Studio 2021.2 on a Pixel 6 with Android 12.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item