### PR TITLE
[FEATURE] Update iOS SDK version

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Updated included iOS SDK to [3.11.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.11.2)
 - Added support for OneSignal Android `setLanguage` callbacks
 
 ## [3.0.2]

--- a/com.onesignal.unity.ios/Editor/OneSignalIOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignalIOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-        <iosPod name="OneSignalXCFramework" version="3.10.0" addToAllTargets="true" />
+        <iosPod name="OneSignalXCFramework" version="3.11.2" addToAllTargets="true" />
     </iosPods>
 </dependencies>


### PR DESCRIPTION
# Description
## One Line Summary
Updates the included OneSignal iOS SDK to the latest version, [3.11.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.11.2).

## Details

### Motivation
Keeps iOS builds made with the OneSignal Unity SDK up to date with changes made in the native OneSignal iOS SDK.

# Testing
## Manual testing
Tested push notifications using NSE features (badge, media attachments, action buttons), app build with Unity Editor 2021.3.0f1 of the Unity Example App on an iPhone 12 with iOS 15.3.1.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/519)
<!-- Reviewable:end -->
