### PR TITLE
[FEATURE] promptForPushNotifications for Android

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Added support for OneSignal Android functionality `promptForPushNotifications`
-- Updated included Android SDK to [4.8.0](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.7.4)
+- Updated included Android SDK to [4.8.0](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.8.0)
 - Updated included iOS SDK to [3.11.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.11.2)
 - Added support for OneSignal Android `setLanguage` callbacks
 
 ## [3.0.2]
 ### Changed
-- Updated included Android SDK to [4.7.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.8.0)
+- Updated included Android SDK to [4.7.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.7.1)
 - Explicitly check for a diff and handle overwrites for the `AndroidManifest.xml` between the project's and package's `OneSignalConfig.plugin`
 - `InstallEdm4uStep` checks for version number to determine if step is completed
 ### Fixed

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -6,13 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Updated included Android SDK to [4.7.4](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.7.4)
+- Added support for OneSignal Android functionality `promptForPushNotifications`
+- Updated included Android SDK to [4.8.0](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.7.4)
 - Updated included iOS SDK to [3.11.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.11.2)
 - Added support for OneSignal Android `setLanguage` callbacks
 
 ## [3.0.2]
 ### Changed
-- Updated included Android SDK to [4.7.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.7.1)
+- Updated included Android SDK to [4.7.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.8.0)
 - Explicitly check for a diff and handle overwrites for the `AndroidManifest.xml` between the project's and package's `OneSignalConfig.plugin`
 - `InstallEdm4uStep` checks for version number to determine if step is completed
 ### Fixed

--- a/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
+++ b/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
@@ -11,7 +11,6 @@
             url "https://repo.maven.apache.org/maven2" // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:5
         }
         mavenLocal()
-        jcenter()
         mavenCentral()
     }
 }
@@ -22,7 +21,7 @@ apply plugin: 'com.android.library'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 // Android Resolver Dependencies Start
-    implementation 'com.onesignal:OneSignal:4.6.5' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
+    implementation 'com.onesignal:OneSignal:4.8.0' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
 // Android Resolver Dependencies End
 **DEPS**}
 

--- a/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
+++ b/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
   <packages>
-    <package>com.onesignal:OneSignal:4.6.5</package>
+    <package>com.onesignal:OneSignal:4.8.0</package>
   </packages>
   <files />
   <settings>

--- a/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
+++ b/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
@@ -3,6 +3,6 @@
     <repositories>
       <repository>https://repo.maven.apache.org/maven2</repository>
     </repositories>
-    <androidPackage spec="com.onesignal:OneSignal:4.7.4" />
+    <androidPackage spec="com.onesignal:OneSignal:4.8.0" />
   </androidPackages>
 </dependencies>

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.Callbacks.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.Callbacks.cs
@@ -287,5 +287,12 @@ namespace OneSignalSDK {
                 _complete(null);
             }
         }
+
+        private sealed class PromptForPushNotificationPermissionResponseHandler : OneSignalAwaitableAndroidJavaProxy<bool> {
+            public PromptForPushNotificationPermissionResponseHandler() : base("PromptForPushNotificationPermissionResponseHandler") { }
+
+            /// <param name="accepted">boolean</param>
+            public void response(bool accepted) => _complete(accepted);
+        }
     }
 }

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
@@ -137,8 +137,11 @@ namespace OneSignalSDK {
             _completedInit(appId);
         }
 
-        public override Task<NotificationPermission> PromptForPushNotificationsWithUserResponse()
-            => Task.FromResult(NotificationPermission.NotDetermined);
+        public override async Task<NotificationPermission> PromptForPushNotificationsWithUserResponse() {
+            var proxy = new PromptForPushNotificationPermissionResponseHandler();
+            _sdkClass.CallStatic("promptForPushNotifications", true, proxy);
+            return await proxy ? NotificationPermission.Authorized : NotificationPermission.Denied;
+        }
 
         public override void ClearOneSignalNotifications()
             => _sdkClass.CallStatic("clearOneSignalNotifications");


### PR DESCRIPTION
# Description
## One Line Summary
Added support for OneSignal Android functionality `promptForPushNotifications`

## Details

### Motivation
Add support for Android 13 notification permission prompt from the native OneSignal Android SDK.

# Testing
## Manual testing
Tested app build with Unity 2021.3.0f1 of the Unity Example App on a Pixel 4 simulator with Android 13.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/522)
<!-- Reviewable:end -->
