### PR TITLE
[FEATURE] Update Android SDK

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Added support for OneSignal Android functionality `promptForPushNotifications`
-- Updated included Android SDK to [4.8.0](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.8.0)
+- Updated included Android SDK to [4.8.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.8.1)
 - Updated included iOS SDK to [3.11.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.11.2)
 - Added support for OneSignal Android `setLanguage` callbacks
 

--- a/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
+++ b/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
@@ -3,6 +3,6 @@
     <repositories>
       <repository>https://repo.maven.apache.org/maven2</repository>
     </repositories>
-    <androidPackage spec="com.onesignal:OneSignal:4.8.0" />
+    <androidPackage spec="com.onesignal:OneSignal:4.8.1" />
   </androidPackages>
 </dependencies>


### PR DESCRIPTION
# Description
## One Line Summary
Updates the included OneSignal Android SDK to the latest version, [4.8.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.8.1).

## Details

### Motivation
Update the Unity SDK with the Android SDK fix.

# Testing
## Manual testing
Tested app build with Unity Editor 2021.3.2f1 of the Unity Example App on a Pixel 6 with Android 12.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/523)
<!-- Reviewable:end -->
