### PR TITLE
[FIX] Java Collection type parameters for Android

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Android `DeleteTags` and `RemovingTriggers` calls correctly use a Java array list instead of an array
+
 ## [3.0.3]
 ### Changed
 - Added support for OneSignal Android functionality `promptForPushNotifications`

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Android `DeleteTags` and `RemovingTriggers` calls correctly use a Java array list instead of an array
+- Android `DeleteTags` and `RemoveTriggers` calls correctly use a Java array list instead of an array
 
 ## [3.0.3]
 ### Changed

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
@@ -170,7 +170,7 @@ namespace OneSignalSDK {
             => _sdkClass.CallStatic("removeTriggerForKey", key);
 
         public override void RemoveTriggers(params string[] keys)
-            => _sdkClass.CallStatic("removeTriggersForKeys", Json.Serialize(keys));
+            => _sdkClass.CallStatic("removeTriggersForKeys", keys.ToArrayList());
 
         public override string GetTrigger(string key) {
             var triggerVal = _sdkClass.CallStatic<AndroidJavaObject>("getTriggerValueForKey", key);
@@ -210,7 +210,7 @@ namespace OneSignalSDK {
 
         public override async Task<bool> DeleteTags(params string[] keys) {
             var proxy = new ChangeTagsUpdateHandler();
-            _sdkClass.CallStatic("deleteTags", keys.ToList(), proxy);
+            _sdkClass.CallStatic("deleteTags", keys.ToArrayList(), proxy);
             return await proxy;
         }
 

--- a/com.onesignal.unity.android/Runtime/Utilities/AndroidJavaObjectExtensions.cs
+++ b/com.onesignal.unity.android/Runtime/Utilities/AndroidJavaObjectExtensions.cs
@@ -111,5 +111,15 @@ namespace OneSignalSDK {
             return map;
         }
 
+        public static AndroidJavaObject ToArrayList(this string[] keys) {
+            AndroidJavaObject arrayList = new AndroidJavaObject("java.util.ArrayList");
+
+            foreach(string key in keys) {
+                arrayList.Call<bool>("add", key);
+            }
+
+            return arrayList;
+        }
+
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Fixes Android `DeleteTags` and `RemoveTriggers` calls to correctly use a Java array list instead of an array.

## Details

### Motivation
Fixes `JNI: Unknown signature` and `java.lang.NoSuchMethodError` errors from calling `DeleteTags` and `RemoveTriggers`.

# Testing
## Manual testing
Tested deleting tags and removing triggers on an app build with Unity 2021.3.2f1 of the Unity Example App on a Pixel 6 with Android 12.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/526)
<!-- Reviewable:end -->
