### PR TITLE
Added #ifdef UNITY_IOS

### DIFF
--- a/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
+++ b/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
@@ -1,3 +1,4 @@
+#if UNITY_IOS
 /*
  * Modified MIT License
  *
@@ -280,3 +281,4 @@ namespace OneSignalSDK {
         }
     }
 }
+#endif // UNITY_IOS

--- a/com.onesignal.unity.ios/Editor/PBXProjectExtensions.cs
+++ b/com.onesignal.unity.ios/Editor/PBXProjectExtensions.cs
@@ -1,3 +1,4 @@
+#if UNITY_IOS
 /*
  * Modified MIT License
  *
@@ -44,3 +45,4 @@ namespace OneSignalSDK {
     #endif
     }
 }
+#endif // UNITY_IOS


### PR DESCRIPTION
A quick fix for issue #508.

Added #ifdef UNITY_IOS for the two build files in the IOS project so that a CI builder like [game.ci](game.ci) can build Android in environments without the iOS modules.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/532)
<!-- Reviewable:end -->
