### PR TITLE
Disable bitcode for OneSignalNotificationServiceExtension

### DIFF
--- a/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
+++ b/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
@@ -187,6 +187,7 @@ namespace OneSignalSDK {
             _project.SetBuildProperty(extensionGuid, "SWIFT_VERSION", "5.0");
             _project.SetBuildProperty(extensionGuid, "ARCHS", "arm64");
             _project.SetBuildProperty(extensionGuid, "DEVELOPMENT_TEAM", PlayerSettings.iOS.appleDeveloperTeamID);
+            _project.SetBuildProperty(extensionGuid, "ENABLE_BITCODE", "NO");
 
             _project.AddBuildProperty(extensionGuid, "LIBRARY_SEARCH_PATHS",
                 $"$(PROJECT_DIR)/Libraries/{PluginLibrariesPath.Replace("\\", "/")}");


### PR DESCRIPTION
Fix for the https://github.com/OneSignal/OneSignal-Unity-SDK/issues/540

According to Xcode documentation bitcode is no longer supported by Xcode 14

https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes

> Starting with Xcode 14, bitcode is no longer required for watchOS and tvOS applications, and the App Store no longer accepts bitcode submissions from Xcode 14.
> 
> Xcode no longer builds bitcode by default and generates a warning message if a project explicitly enables bitcode: “Building with bitcode is deprecated. Please update your project and/or target settings to disable bitcode.” The capability to build with bitcode will be removed in a future Xcode release. IPAs that contain bitcode will have the bitcode stripped before being submitted to the App Store. Debug symbols for past bitcode submissions remain available for download. (86118779)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/546)
<!-- Reviewable:end -->
