### PR TITLE
Correct OneSignal.Version constant value

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed OneSignal.Version constant value
+
 ## [3.0.4]
 ### Fixed
 - Android `DeleteTags` and `RemoveTriggers` calls correctly use a Java array list instead of an array

--- a/com.onesignal.unity.core/Runtime/OneSignal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.cs
@@ -34,7 +34,7 @@ namespace OneSignalSDK {
     /// OneSignal SDK for Unity
     /// </summary>
     public abstract partial class OneSignal {
-        public const string Version = "3.0.0";
+        public const string Version = "3.0.4";
 
         /// <summary>
         /// The default static instance of the OneSignal Unity SDK

--- a/com.onesignal.unity.core/Runtime/OneSignal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.cs
@@ -34,7 +34,7 @@ namespace OneSignalSDK {
     /// OneSignal SDK for Unity
     /// </summary>
     public abstract partial class OneSignal {
-        public const string Version = "3.0.4";
+        public const string Version = "3.0.5";
 
         /// <summary>
         /// The default static instance of the OneSignal Unity SDK


### PR DESCRIPTION
It's very confusing to see 3.0.0 in the log messages when the package version is 3.0.4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/549)
<!-- Reviewable:end -->
