### PR TITLE
Fixed app group name to be a property. Fixes [#545]

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated included iOS SDK to [3.11.5](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.11.5)
 ### Fixed
 - Log current version number of the OneSignal SDK
+- Fixed app group name to be a property. Fixes [#545](https://github.com/OneSignal/OneSignal-Unity-SDK/issues/545)
 
 ## [3.0.4]
 ### Fixed

--- a/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
+++ b/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
@@ -75,12 +75,12 @@ namespace OneSignalSDK {
         private static readonly string PluginLibrariesPath = Path.Combine(PackageName, "Runtime", "Plugins", "iOS");
         private static readonly string PluginFilesPath = Path.Combine("Packages", PluginLibrariesPath);
 
-        private readonly string _appGroupName = $"group.{PlayerSettings.applicationIdentifier}.onesignal";
-        
         private string _outputPath;
         private string _projectPath;
-        
+
         private readonly PBXProject _project = new PBXProject();
+
+        private string _appGroupName => $"group.{PlayerSettings.applicationIdentifier}.onesignal";
 
         /// <summary>
         /// must be between 40 and 50 to ensure that it's not overriden by Podfile generation (40) and that it's


### PR DESCRIPTION
# Description
## One Line Summary
Fixes app group name not being dynamic. More info on this issue #545.
## Details

### Motivation
If a previous pre/post-process script changes the bundle identifier, OneSignal's BuildPostProcessor script uses the wrong bundle identifier and it is causing CI build errors.

# Testing
## Unit testing
No unit test here, not required.

## Manual testing
Tested on a CI build.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/555)
<!-- Reviewable:end -->
