### PR TITLE
[Fix] Android builds without iOS modules

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,13 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Android builds failing without the Unity iOS module
+- Fixed app group name to be a property. Fixes [#545](https://github.com/OneSignal/OneSignal-Unity-SDK/issues/545)
+
 ## [3.0.5]
 ### Changed
 - Updated included Android SDK to [4.8.3](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.8.3)
 - Updated included iOS SDK to [3.11.5](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.11.5)
 ### Fixed
 - Log current version number of the OneSignal SDK
-- Fixed app group name to be a property. Fixes [#545](https://github.com/OneSignal/OneSignal-Unity-SDK/issues/545)
 
 ## [3.0.4]
 ### Fixed

--- a/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
+++ b/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
@@ -42,6 +42,8 @@
  * 6. Observe Badge value is 1. (If it is 3 there is an App Group issue)
 */
 
+#if UNITY_IOS
+
 // Flag if an App Group should created for the main target and the NSE
 // Try renaming NOTIFICATION_SERVICE_EXTENSION_TARGET_NAME below first before
 //   removing ADD_APP_GROUP if you run into Provisioning errors in Xcode that
@@ -280,3 +282,4 @@ namespace OneSignalSDK {
         }
     }
 }
+#endif

--- a/com.onesignal.unity.ios/Editor/PBXProjectExtensions.cs
+++ b/com.onesignal.unity.ios/Editor/PBXProjectExtensions.cs
@@ -25,6 +25,7 @@
  * THE SOFTWARE.
  */
 
+#if UNITY_IOS
 using UnityEditor.iOS.Xcode;
 
 namespace OneSignalSDK {
@@ -44,3 +45,4 @@ namespace OneSignalSDK {
     #endif
     }
 }
+#endif


### PR DESCRIPTION
# Description
## One Line Summary
Fixes Android builds failing without the Unity iOS module.

## Details

### Motivation
Allows Android builds to compile without the Unity iOS module and fixes Android builds for CI builders. Addresses [#508](https://github.com/OneSignal/OneSignal-Unity-SDK/issues/508)

# Testing
## Manual testing
Tested building the example app for Android without the Unity iOS module installed on 2020.3.41f1.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/556)
<!-- Reviewable:end -->
