### PR TITLE
[Feature] Live activities

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated included iOS SDK to [3.12.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.12.2)
+- Added support for OneSignal iOS functionality `enterLiveActivity` and `exitLiveActivity`
+
 ## [3.0.6]
 ### Fixed
 - Android builds failing without the Unity iOS module

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
@@ -281,5 +281,15 @@ namespace OneSignalSDK {
             _sdkClass.CallStatic("sendOutcomeWithValue", name, value, proxy);
             return await proxy;
         }
+
+        public override Task<bool> enterLiveActivity(string activityId, string token) {
+            SDKDebug.Warn("This feature is only available for iOS.");
+            return Task.FromResult(false);
+        }
+
+        public override Task<bool> exitLiveActivity(string activityId) {
+            SDKDebug.Warn("This feature is only available for iOS.");
+            return Task.FromResult(false);
+        }
     }
 }

--- a/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
+++ b/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
@@ -174,5 +174,13 @@ namespace OneSignalSDK {
         public override Task<bool> SendOutcomeWithValue(string name, float value) {
             return Task.FromResult(false);
         }
+
+        public override Task<bool> enterLiveActivity(string activityId, string token) {
+            return Task.FromResult(false);
+        }
+
+        public override Task<bool> exitLiveActivity(string activityId) {
+            return Task.FromResult(false);
+        }
     }
 }

--- a/com.onesignal.unity.core/Runtime/OneSignal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.cs
@@ -385,7 +385,6 @@ namespace OneSignalSDK {
         /// <summary>
         /// Helper method to show the native prompt to ask the user for consent to share their location
         /// </summary>
-        /// <remarks>iOS Only</remarks>
         public abstract void PromptLocation();
 
         /// <summary>
@@ -413,6 +412,23 @@ namespace OneSignalSDK {
         /// </summary>
         /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
         public abstract Task<bool> SendOutcomeWithValue(string name, float value);
+    #endregion
+
+    #region Live Activity
+        /// <summary>
+        /// Associates a customer defined activityId with a live activity temporary push token on OneSignal's server
+        /// </summary>
+        /// <remarks>iOS Only</remarks>
+        /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
+        public abstract Task<bool> enterLiveActivity(string activityId, string token);
+
+        /// <summary>
+        /// Deletes the association between a customer defined activityId with a Live Activity temporary push token on
+        /// OneSignal's server
+        /// </summary>
+        /// <remarks>iOS Only</remarks>
+        /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
+        public abstract Task<bool> exitLiveActivity(string activityId);
     #endregion
 
     }

--- a/com.onesignal.unity.ios/Editor/OneSignalIOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignalIOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-        <iosPod name="OneSignalXCFramework" version="3.12.1" addToAllTargets="true" />
+        <iosPod name="OneSignalXCFramework" version="3.12.2" addToAllTargets="true" />
     </iosPods>
 </dependencies>

--- a/com.onesignal.unity.ios/Editor/OneSignalIOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignalIOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-        <iosPod name="OneSignalXCFramework" version="3.11.5" addToAllTargets="true" />
+        <iosPod name="OneSignalXCFramework" version="3.12.1" addToAllTargets="true" />
     </iosPods>
 </dependencies>

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.Interface.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.Interface.cs
@@ -95,5 +95,8 @@ namespace OneSignalSDK {
         [DllImport("__Internal")] private static extern void _sendOutcome(string name, int hashCode, BooleanResponseDelegate callback);
         [DllImport("__Internal")] private static extern void _sendUniqueOutcome(string name, int hashCode, BooleanResponseDelegate callback);
         [DllImport("__Internal")] private static extern void _sendOutcomeWithValue(string name, float value, int hashCode, BooleanResponseDelegate callback);
+
+        [DllImport("__Internal")] private static extern void _enterLiveActivity(string activityId, string token, int hashCode, BooleanResponseDelegate callback);
+        [DllImport("__Internal")] private static extern void _exitLiveActivity(string activityId, int hashCode, BooleanResponseDelegate callback);
     }
 }

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
@@ -241,5 +241,17 @@ namespace OneSignalSDK {
             _sendOutcomeWithValue(name, value, hashCode, BooleanCallbackProxy);
             return await proxy;
         }
+
+        public override async Task<bool> enterLiveActivity(string activityId, string token) {
+            var (proxy, hashCode) = _setupProxy<bool>();
+            _enterLiveActivity(activityId, token, hashCode, BooleanCallbackProxy);
+            return await proxy;
+        }
+
+        public override async Task<bool> exitLiveActivity(string activityId) {
+            var (proxy, hashCode) = _setupProxy<bool>();
+            _exitLiveActivity(activityId, hashCode, BooleanCallbackProxy);
+            return await proxy;
+        }
     }
 }

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridge.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridge.mm
@@ -425,6 +425,17 @@ void _sendOutcomeWithValue(const char* name, float value, int hashCode, BooleanR
                               value:@(value)
                           onSuccess:^(OSOutcomeEvent *outcome) { CALLBACK(outcome != nil); }];
 }
+
+void _enterLiveActivity(const char* activityId, const char* token, int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal enterLiveActivity:TO_NSSTRING(activityId)
+                       withToken:TO_NSSTRING(token)
+                     withSuccess:^(NSDictionary *result) { CALLBACK(YES); }
+                     withFailure:^(NSError *error) { CALLBACK(NO); }];
 }
 
-
+void _exitLiveActivity(const char* activityId, int hashCode, BooleanResponseDelegate callback) {
+    [OneSignal exitLiveActivity:TO_NSSTRING(activityId)
+                    withSuccess:^(NSDictionary *result) { CALLBACK(YES); }
+                    withFailure:^(NSError *error) { CALLBACK(NO); }];
+}
+}


### PR DESCRIPTION
# Description
## One Line Summary
Adds live activity methods from the iOS SDK

## Details

### Motivation
iOS feature to allow entering and exiting live activities through OneSignal.

# Testing
## Manual testing
Tested calling exit and enter live activity methods on app build with Android 2021.3.1 on a Pixel 4 simulator with Android 12 and Xcode 14.1 build with a iOS iPhone 12 on iOS 15.5.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/559)
<!-- Reviewable:end -->
