### PR TITLE
[Fix] Serialization depth warning

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Updated Unity Verified Solutions Attribution script from VspAttribution to VSAttribution
+### Fixed
+- Resolved serialization depth limit 10 exceeded warning log
 
 ## [3.0.7]
 ### Changed

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.Mappings.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.Mappings.cs
@@ -58,11 +58,17 @@ namespace OneSignalSDK {
 
         private static Notification _getNotification(AndroidJavaObject notifJO) {
             var notification = notifJO.ToSerializable<Notification>();
-                
+            
             var dataJson = notifJO.Call<AndroidJavaObject>("getAdditionalData");
             if (dataJson != null) {
                 var dataJsonStr = dataJson.Call<string>("toString");
                 notification.additionalData = Json.Deserialize(dataJsonStr) as Dictionary<string, object>;
+            }
+
+            var groupedNotificationsJson = notifJO.Call<AndroidJavaObject>("getGroupedNotifications");
+            if (groupedNotificationsJson != null) {
+                var groupedNotificationsStr = groupedNotificationsJson.Call<string>("toString");
+                notification.groupedNotifications = Json.Deserialize(groupedNotificationsStr) as List<NotificationBase>;
             }
 
             return notification;

--- a/com.onesignal.unity.core/Runtime/Models/Notification.cs
+++ b/com.onesignal.unity.core/Runtime/Models/Notification.cs
@@ -59,7 +59,7 @@ namespace OneSignalSDK {
     /// See full documentation at
     /// https://documentation.onesignal.com/docs/sdk-notification-event-handlers#osnotification-class
     /// </summary>
-    [Serializable] public sealed class Notification {
+    [Serializable] public class NotificationBase {
         /// <summary>
         /// OneSignal notification UUID
         /// </summary>
@@ -185,12 +185,6 @@ namespace OneSignalSDK {
         /// <remarks>Android only</remarks>
         public int priority;
 
-        /// <summary>
-        /// Gets the notification payloads a summary notification was created from
-        /// </summary>
-        /// <remarks>Android only</remarks>
-        public List<Notification> groupedNotifications;
-
         /// </summary>
         /// If a background image was set, this object will be available
         /// </summary>
@@ -265,5 +259,13 @@ namespace OneSignalSDK {
         /// <remarks>iOS 10+ only</remarks>
         public Dictionary<string, object> attachments;
     #endregion
+    }
+
+    [Serializable] public sealed class Notification : NotificationBase {
+        /// <summary>
+        /// Gets the notification payloads a summary notification was created from
+        /// </summary>
+        /// <remarks>Android only</remarks>
+        public List<NotificationBase> groupedNotifications;
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Resolved `The Serialization depth limit 10 exceeded at 'OneSignalSDK::Notification.actionButtons'. …` warning log from appearing when a notification is opened or received.

## Details

### Motivation
Resolves warning log

### Scope
The `Notification` `groupedNotifications` property is now a list of type `NotificationBase` instead of a list of type `Notification`.

# Testing
## Manual testing
Tested receiving and opening a notification, app build with Android 2021.3.1 with a fresh install of the OneSignal example app on a Pixel 4 simulator with Android 12 and Xcode 14.1 build with an iOS iPhone 12 on iOS 15.5.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/567)
<!-- Reviewable:end -->
