### PR TITLE
[Fix] Live activity method names

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Renamed `enterLiveActivity` to `EnterLiveActivity` and `exitLiveActivity` to `ExitLiveActivity`
 - Updated Unity Verified Solutions Attribution script from VspAttribution to VSAttribution
 ### Fixed
 - Resolved serialization depth limit 10 exceeded warning log

--- a/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
+++ b/com.onesignal.unity.android/Runtime/OneSignalAndroid.cs
@@ -282,12 +282,12 @@ namespace OneSignalSDK {
             return await proxy;
         }
 
-        public override Task<bool> enterLiveActivity(string activityId, string token) {
+        public override Task<bool> EnterLiveActivity(string activityId, string token) {
             SDKDebug.Warn("This feature is only available for iOS.");
             return Task.FromResult(false);
         }
 
-        public override Task<bool> exitLiveActivity(string activityId) {
+        public override Task<bool> ExitLiveActivity(string activityId) {
             SDKDebug.Warn("This feature is only available for iOS.");
             return Task.FromResult(false);
         }

--- a/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
+++ b/com.onesignal.unity.core/Editor/Platform/OneSignalNative.cs
@@ -175,11 +175,11 @@ namespace OneSignalSDK {
             return Task.FromResult(false);
         }
 
-        public override Task<bool> enterLiveActivity(string activityId, string token) {
+        public override Task<bool> EnterLiveActivity(string activityId, string token) {
             return Task.FromResult(false);
         }
 
-        public override Task<bool> exitLiveActivity(string activityId) {
+        public override Task<bool> ExitLiveActivity(string activityId) {
             return Task.FromResult(false);
         }
     }

--- a/com.onesignal.unity.core/Runtime/OneSignal.cs
+++ b/com.onesignal.unity.core/Runtime/OneSignal.cs
@@ -420,7 +420,7 @@ namespace OneSignalSDK {
         /// </summary>
         /// <remarks>iOS Only</remarks>
         /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
-        public abstract Task<bool> enterLiveActivity(string activityId, string token);
+        public abstract Task<bool> EnterLiveActivity(string activityId, string token);
 
         /// <summary>
         /// Deletes the association between a customer defined activityId with a Live Activity temporary push token on
@@ -428,7 +428,7 @@ namespace OneSignalSDK {
         /// </summary>
         /// <remarks>iOS Only</remarks>
         /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
-        public abstract Task<bool> exitLiveActivity(string activityId);
+        public abstract Task<bool> ExitLiveActivity(string activityId);
     #endregion
 
     }

--- a/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignalIOS.cs
@@ -242,13 +242,13 @@ namespace OneSignalSDK {
             return await proxy;
         }
 
-        public override async Task<bool> enterLiveActivity(string activityId, string token) {
+        public override async Task<bool> EnterLiveActivity(string activityId, string token) {
             var (proxy, hashCode) = _setupProxy<bool>();
             _enterLiveActivity(activityId, token, hashCode, BooleanCallbackProxy);
             return await proxy;
         }
 
-        public override async Task<bool> exitLiveActivity(string activityId) {
+        public override async Task<bool> ExitLiveActivity(string activityId) {
             var (proxy, hashCode) = _setupProxy<bool>();
             _exitLiveActivity(activityId, hashCode, BooleanCallbackProxy);
             return await proxy;


### PR DESCRIPTION
# Description
## One Line Summary
Renamed `enterLiveActivity` to `EnterLiveActivity` and `exitLiveActivity` to `ExitLiveActivity`

## Details

### Motivation
Fixes live activity method names to be capitalized

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/569)
<!-- Reviewable:end -->
