### PR TITLE
[Fix] Lock OneSignal Android Version

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Android - Lock OneSignal version so it doesn't get bumped to the next major version.
 ## [3.0.8]
 ### Changed
 - Renamed `enterLiveActivity` to `EnterLiveActivity` and `exitLiveActivity` to `ExitLiveActivity`

--- a/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
+++ b/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
@@ -3,6 +3,6 @@
     <repositories>
       <repository>https://repo.maven.apache.org/maven2</repository>
     </repositories>
-    <androidPackage spec="com.onesignal:OneSignal:4.8.3" />
+    <androidPackage spec="com.onesignal:OneSignal:[4.8.3]" />
   </androidPackages>
 </dependencies>


### PR DESCRIPTION
# Description
## One Line Summary
Fixes Android build errors not finding OneSignal classes due to the Android OneSignal version being bumped to the next major version.

## Details
This prevents it from being bumped by EDM4U which can cause unpredictable behavior.

### Motivation
Critical fix for broken Android builds for most projects for all previous existing versions of OneSignal. This resolves #573 which was due to EDM4U bumping to the major 5.0.0 version of OneSignal which has breaking API changes. 

### Scope
Only effects Android builds. Issue only when other libraries are also in the project that use newer versions of OneSignal's dependencies, however this is quite common.

# Testing
## Unit testing
None, no existing tests around this.

## Manual testing
Tested with a new Unity project with:
* macOS 13.1
* Unity 2021.3.16f1
* FirebaseAuth 10.3.0
I reproduced the issue and ensured the locking change here fixed the problem.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk/575)
<!-- Reviewable:end -->
