### PR TITLE
[User model] Add a helper method to the iOS plugin

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Added helper methods in the iOS OneSignal bridge
+
 ## [5.0.0-beta.2]
 ### Added
 - Sdk type and version to api headers
@@ -32,7 +35,6 @@ If you run into any problems, please don’t hesitate to add to this [issue](htt
 - Updated Unity Verified Solutions Attribution script from VspAttribution to VSAttribution
 ### Fixed
 - Resolved serialization depth limit 10 exceeded warning log
-- Fixed InstallEdm4uStep to work with UPM EDM4U installations
 
 ## [3.0.7]
 ### Changed

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalBridgeUtil.h
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalBridgeUtil.h
@@ -27,9 +27,10 @@
 
 #import <UIKit/UIKit.h>
 
-@interface OneSignalBridgeUtil
+@interface OneSignalBridgeUtil : NSObject
 
 const char* jsonStringFromDictionary(NSDictionary *dictionary);
-// TObj objFromJsonString(const char* jsonString);
+NSDictionary* dictionaryFromJsonString(const char* jsonString);
+NSArray* arrayFromJsonString(const char* jsonString);
 
 @end

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalBridgeUtil.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalBridgeUtil.mm
@@ -28,6 +28,7 @@
 #import "OneSignalBridgeUtil.h"
 
 @implementation OneSignalBridgeUtil
+
 const char* jsonStringFromDictionary(NSDictionary *dictionary) {
     NSError *error;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&error];
@@ -35,15 +36,24 @@ const char* jsonStringFromDictionary(NSDictionary *dictionary) {
     return [jsonString UTF8String];
 }
 
-// template <typename TObj>
-// TObj objFromJsonString(const char* jsonString) {
-//     NSData* jsonData = [[NSString stringWithUTF8String:jsonString] dataUsingEncoding:NSUTF8StringEncoding];
-//     NSError* error = nil;
-//     TObj arr = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+template <typename TObj>
+TObj objFromJsonString(const char* jsonString) {
+    NSData* jsonData = [[NSString stringWithUTF8String:jsonString] dataUsingEncoding:NSUTF8StringEncoding];
+    NSError* error = nil;
+    TObj arr = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
 
-//     if (error != nil)
-//         return nil;
+    if (error != nil)
+        return nil;
 
-//     return arr;
-// }
+    return arr;
+}
+
+NSDictionary* dictionaryFromJsonString(const char* jsonString) {
+    return objFromJsonString<NSDictionary*>(jsonString);
+}
+
+NSArray* arrayFromJsonString(const char* jsonString) {
+    return objFromJsonString<NSArray*>(jsonString);
+}
+
 @end

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeInAppMessages.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeInAppMessages.mm
@@ -39,18 +39,6 @@ typedef void (*StringListenerDelegate)(const char* response);
 #define CALLBACK(value) callback(hashCode, value)
 #define TO_NSSTRING(cstr) cstr ? [NSString stringWithUTF8String:cstr] : nil
 
-template <typename TObj>
-TObj objFromJsonString(const char* jsonString) {
-    NSData* jsonData = [[NSString stringWithUTF8String:jsonString] dataUsingEncoding:NSUTF8StringEncoding];
-    NSError* error = nil;
-    TObj arr = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
-
-    if (error != nil)
-        return nil;
-
-    return arr;
-}
-
 /*
  * Observer singleton for global callbacks
  */
@@ -146,7 +134,7 @@ extern "C" {
     }
 
     void _inAppMessagesAddTriggers(const char* triggersJson) {
-        NSDictionary *triggers = objFromJsonString<NSDictionary*>(triggersJson);
+        NSDictionary *triggers = dictionaryFromJsonString(triggersJson);
 
         [OneSignal.InAppMessages addTriggers:triggers];
     }
@@ -156,7 +144,7 @@ extern "C" {
     }
 
     void _inAppMessagesRemoveTriggers(const char* triggersJson) {
-        NSArray *triggers = objFromJsonString<NSArray*>(triggersJson);
+        NSArray *triggers = arrayFromJsonString(triggersJson);
 
         [OneSignal.InAppMessages removeTriggers:triggers];
     }

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeUser.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeUser.mm
@@ -38,18 +38,6 @@ typedef void (*StateListenerDelegate)(const char* current, const char* previous)
 
 #define TO_NSSTRING(cstr) cstr ? [NSString stringWithUTF8String:cstr] : nil
 
-template <typename TObj>
-TObj objFromJsonString2(const char* jsonString) {
-    NSData* jsonData = [[NSString stringWithUTF8String:jsonString] dataUsingEncoding:NSUTF8StringEncoding];
-    NSError* error = nil;
-    TObj arr = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
-
-    if (error != nil)
-        return nil;
-
-    return arr;
-}
-
 /*
  * Observer singleton for global callbacks
  */
@@ -109,7 +97,7 @@ extern "C" {
     }
 
     void _userAddAliases(const char* aliasesJson) {
-        NSDictionary *aliases = objFromJsonString2<NSDictionary*>(aliasesJson);
+        NSDictionary *aliases = dictionaryFromJsonString(aliasesJson);
 
         [OneSignal.User addAliases:aliases];
     }
@@ -119,7 +107,7 @@ extern "C" {
     }
 
     void _userRemoveAliases(const char* aliasesJson) {
-        NSArray *aliases = objFromJsonString2<NSArray*>(aliasesJson);
+        NSArray *aliases = arrayFromJsonString(aliasesJson);
 
         if (aliases == nil) {
             NSLog(@"[Onesignal] Could not parse aliases to delete");
@@ -151,7 +139,7 @@ extern "C" {
     }
 
     void _userAddTags(const char* tagsJson) {
-        NSDictionary *tags = objFromJsonString2<NSDictionary*>(tagsJson);
+        NSDictionary *tags = dictionaryFromJsonString(tagsJson);
 
         [OneSignal.User addTags:tags];
     }
@@ -161,7 +149,7 @@ extern "C" {
     }
 
     void _userRemoveTags(const char* tagsJson) {
-        NSArray *tags = objFromJsonString2<NSArray*>(tagsJson);
+        NSArray *tags = arrayFromJsonString(tagsJson);
 
         if (tags == nil) {
             NSLog(@"[Onesignal] Could not parse tags to delete");


### PR DESCRIPTION
# Description
## One Line Summary
Adds a helper method to the iOS plugin

## Details

### Motivation
Cleans up the internal code a bit

### Scope
No external functionality should be affected

# Testing
## Manual testing
Tested adding and removing a trigger, alias, and tag. App build with Xcode 14.2 with the OneSignal example app on an iPhone 12 on iOS 15.5.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/591)
<!-- Reviewable:end -->
