### PR TITLE
[FEATURE] Update OneSignal Android and iOS SDK

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,6 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
-      - develop
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,16 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed InstallEdm4uStep to work with UPM EDM4U installations
+
 ## [3.0.9]
 ### Fixed
 - Android - Lock OneSignal version so it doesn't get bumped to the next major version.
+
 ## [3.0.8]
 ### Changed
 - Renamed `enterLiveActivity` to `EnterLiveActivity` and `exitLiveActivity` to `ExitLiveActivity`
 - Updated Unity Verified Solutions Attribution script from VspAttribution to VSAttribution
 ### Fixed
 - Resolved serialization depth limit 10 exceeded warning log
-- Fixed InstallEdm4uStep to work with UPM EDM4U installations
 
 ## [3.0.7]
 ### Changed

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated included Android SDK to [4.8.5](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.8.5)
+- Updated included iOS SDK to [3.12.4](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.12.4)
 ### Fixed
 - Fixed InstallEdm4uStep to work with UPM EDM4U installations
 

--- a/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
+++ b/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
@@ -3,6 +3,6 @@
     <repositories>
       <repository>https://repo.maven.apache.org/maven2</repository>
     </repositories>
-    <androidPackage spec="com.onesignal:OneSignal:[4.8.3]" />
+    <androidPackage spec="com.onesignal:OneSignal:[4.8.5]" />
   </androidPackages>
 </dependencies>

--- a/com.onesignal.unity.ios/Editor/OneSignalIOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignalIOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-        <iosPod name="OneSignalXCFramework" version="3.12.3" addToAllTargets="true" />
+        <iosPod name="OneSignalXCFramework" version="3.12.4" addToAllTargets="true" />
     </iosPods>
 </dependencies>


### PR DESCRIPTION
# Description
## One Line Summary
Updates included OneSignal Android and iOS SDKs to the latest version.

## Details

### Motivation
Bumps Android SDK from [4.8.3](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.8.3) to [4.8.5](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.8.5).
Bumps iOS SDK from [3.12.3](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.12.3) to [3.12.4](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/3.12.4).

# Testing
## Manual testing
Tested OneSignal initialization, app build with Unity 2020.3.43f1 of the OneSignal example app on a emulated Pixel 4 with Android 12 and physical iPhone 12 with iOS 15.5.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/595)
<!-- Reviewable:end -->
