### PR TITLE
[Fix] ANRs for callbacks and when backgrounding app

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed rare Android ANRs on callbacks firing and also when backgrounding the app.
 ## [3.0.10]
 ### Changed
 - Updated included Android SDK to [4.8.5](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/4.8.5)

--- a/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
+++ b/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
@@ -3,6 +3,6 @@
     <repositories>
       <repository>https://repo.maven.apache.org/maven2</repository>
     </repositories>
-    <androidPackage spec="com.onesignal:OneSignal:[4.8.5]" />
+    <androidPackage spec="com.onesignal:OneSignal:[4.8.6]" />
   </androidPackages>
 </dependencies>


### PR DESCRIPTION
# Description
## One Line Summary
Fix rare Android ANRs when OneSignal callbacks fire and when the app is backgrounded.

## Details

### Motivation
The time spent on the main thread in this scenario is significantly contributing to ANRs. The Google Play store penalizes apps with ANRs with lower search rankings and possibly some other negatives.

### Scope
Only effects Android and threading used for callbacks, observers, and events like click.

### Dependent OneSignal-Android-SDK PRs
These are the two PRs that were included in the OneSignal-Android-SDK 4.8.6 release this PR depends on:
* https://github.com/OneSignal/OneSignal-Android-SDK/pull/1775
* https://github.com/OneSignal/OneSignal-Android-SDK/pull/1776

# Testing
## Unit testing
None

## Manual testing
Tested on Samsung S21 with Android 13. Ensured `SetExternalUserId`'s callback still fires in the example app here.
Also ensured the threading preference value did change by printing its value back in C#.
```C#
var preferenceValue = callbackThreadManagerCompanionClass.Call<AndroidJavaObject>("getPreference");
UnityEngine.Debug.Log("preferenceValue: " + preferenceValue.Call<string>("toString"));
```

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/602)
<!-- Reviewable:end -->
