### PR TITLE
[Fix] Push subscription Id and Token on iOS

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,15 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Push subscription Id and Token malloc error on iOS
+
 ## [5.0.0]
 ### Changed
 - Removed `SetLaunchURLsInApp`
 - Removed async from location request permission and updated method name to `RequestPermission`
 - Updated included iOS SDK to [5.0.1](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.0.1)
 - Updated included Android SDK to [5.0.0](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.0.0)
-- Updated default OneSignal Android notificaiton icons to new logo
+- Updated default OneSignal Android notification icons to new logo
 ### Fixed
-- Outcome method calls on Android
+- NoSuchMethodError for outcome methods on Android
 - Completion check for the Copy Android plugin to Assets setup step
 
 ## [5.0.0-beta.3]

--- a/OneSignalExample/Assets/OneSignal/Example/OneSignalExampleBehaviour.cs
+++ b/OneSignalExample/Assets/OneSignal/Example/OneSignalExampleBehaviour.cs
@@ -135,7 +135,7 @@ public class OneSignalExampleBehaviour : MonoBehaviour {
     /// </summary>
     private void Start() {
         // Enable lines below to debug issues with OneSignal
-        OneSignal.Debug.LogLevel = LogLevel.Verbose;
+        OneSignal.Debug.LogLevel = LogLevel.Info;
         OneSignal.Debug.AlertLevel = LogLevel.Fatal;
 
         _log($"Initializing with appId <b>{appId}</b>");
@@ -230,16 +230,12 @@ public class OneSignalExampleBehaviour : MonoBehaviour {
     public void SetLogLevel() {
         var newLevel = _nextEnum(OneSignal.Debug.LogLevel);
         _log($"Setting LogLevel to <b>{newLevel}</b>");
-        
-        // LogLevel uses the standard Unity LogType
         OneSignal.Debug.LogLevel = newLevel;
     }
 
     public void SetAlertLevel() {
         var newLevel = _nextEnum(OneSignal.Debug.AlertLevel);
         _log($"Setting AlertLevel to <b>{newLevel}</b>");
-
-        // AlertLevel uses the standard Unity LogType
         OneSignal.Debug.AlertLevel = newLevel;
     }
 

--- a/com.onesignal.unity.core/Samples~/OneSignalExampleBehaviour.cs
+++ b/com.onesignal.unity.core/Samples~/OneSignalExampleBehaviour.cs
@@ -230,16 +230,12 @@ public class OneSignalExampleBehaviour : MonoBehaviour {
     public void SetLogLevel() {
         var newLevel = _nextEnum(OneSignal.Debug.LogLevel);
         _log($"Setting LogLevel to <b>{newLevel}</b>");
-        
-        // LogLevel uses the standard Unity LogType
         OneSignal.Debug.LogLevel = newLevel;
     }
 
     public void SetAlertLevel() {
         var newLevel = _nextEnum(OneSignal.Debug.AlertLevel);
         _log($"Setting AlertLevel to <b>{newLevel}</b>");
-
-        // AlertLevel uses the standard Unity LogType
         OneSignal.Debug.AlertLevel = newLevel;
     }
 

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeUser.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeUser.mm
@@ -80,6 +80,7 @@ typedef void (*StateListenerDelegate)(const char* current, const char* previous)
 
 /*
  * Bridge methods
+ * We use strdup because Unity attempts to free the memory after we return the value
  */
 
 extern "C" {
@@ -156,11 +157,11 @@ extern "C" {
     }
 
     const char* _pushSubscriptionGetId() {
-        return [OneSignal.User.pushSubscription.id UTF8String];
+        return strdup([OneSignal.User.pushSubscription.id UTF8String]);
     }
 
     const char* _pushSubscriptionGetToken() {
-        return [OneSignal.User.pushSubscription.token UTF8String];
+        return strdup([OneSignal.User.pushSubscription.token UTF8String]);
     }
 
     bool _pushSubscriptionGetOptedIn() {


### PR DESCRIPTION
# Description
## One Line Summary
Fixes malloc error on iOS when calling `OneSignal.User.PushSubscription.Id` or `OneSignal.User.PushSubscription.Token`.

## Details

### Motivation
Addresses reported issue https://github.com/OneSignal/OneSignal-Unity-SDK/issues/628, "pointer being freed was not allocated" when returning a string from the iOS bridge.

# Testing
## Manual testing
Tested logging push subscription Id and token, app build with Unity 2021.3.16f1 of the OneSignal example app on a physical iPhone 12 with iOS 15.5.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/629)
<!-- Reviewable:end -->
