### PR TITLE
[Fix] PreventDefualt on iOS

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Stop foreground notifications from displaying after calling prevent default on iOS
+
 ## [5.0.1]
 ### Fixed
 - Push subscription Id and Token malloc error on iOS

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeNotifications.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeNotifications.mm
@@ -71,6 +71,8 @@ typedef void (*ClickListenerDelegate)(const char* notification, const char* resu
         [OneSignal.Notifications addPermissionObserver:self];
         [OneSignal.Notifications addForegroundLifecycleListener:self];
         [OneSignal.Notifications addClickListener:self];
+
+        _willDisplayEvents = [NSMutableDictionary new];
     }
 
     return self;
@@ -84,10 +86,10 @@ typedef void (*ClickListenerDelegate)(const char* notification, const char* resu
 
 - (void)onWillDisplayNotification:(OSNotificationWillDisplayEvent *)event {
     if (_willDisplayDelegate != nil) {
+        _willDisplayEvents[event.notification.notificationId] = event;
+
         NSString *stringNotification = [event.notification stringify];
         _willDisplayDelegate([stringNotification UTF8String]);
-
-        _willDisplayEvents[event.notification.notificationId] = event;
     }
 }
 

--- a/com.onesignal.unity.ios/Runtime/iOSNotificationsManager.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSNotificationsManager.cs
@@ -114,7 +114,7 @@ namespace OneSignalSDK.iOS.Notifications {
             {
                 // We use Send instead of Post because we need to *not* return to our caller until the
                 // event handlers have returned themselves. This allows a handler to call PreventDefault()
-                // which will get passed down to Android in InternalNotificationWillDisplayEventArgs.
+                // which will get passed down to iOS in InternalNotificationWillDisplayEventArgs.
                 UnityMainThreadDispatch.Send(state => handler(_instance, args));
             }
         }


### PR DESCRIPTION
# Description
## One Line Summary
Stop foreground notifications from displaying after calling prevent default on iOS

## Details

### Motivation
Fixes user reported bug  https://github.com/OneSignal/OneSignal-Unity-SDK/issues/628 where calling prevent default still displays the notification on iOS

# Testing
## Manual testing
Tested displaying a notification in the foreground, app build with Unity 2021.3.16f1 of the OneSignal example app on a physical iPhone 12 with iOS 15.5.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/635)
<!-- Reviewable:end -->
