### PR TITLE
[Fix] iOS notifications clicked event to fire on cold start

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated included iOS SDK to [5.0.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.0.2)
 ### Fixed
 - Sending VSAttribution data from the editor
-- iOS notifications clicked event to fire when app is opened from clicking on a notification
+- iOS notifications clicked event firing if the app was cold started from clicking a notification
 
 ## [5.0.2]
 ### Fixed

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `InstallEdm4uStep` now imports version [1.2.177](https://github.com/googlesamples/unity-jar-resolver/releases/tag/v1.2.177) of [EDM4U](https://github.com/googlesamples/unity-jar-resolver)
 - Updated included Android SDK to [5.0.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.0.1)
+- Updated included iOS SDK to [5.0.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.0.2)
 ### Fixed
 - Sending VSAttribution data from the editor
 

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated included iOS SDK to [5.0.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.0.2)
 ### Fixed
 - Sending VSAttribution data from the editor
+- iOS notifications clicked event to fire when app is opened from clicking on a notification
 
 ## [5.0.2]
 ### Fixed

--- a/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-            <iosPod name="OneSignalXCFramework" version="5.0.1" addToAllTargets="true" />
+            <iosPod name="OneSignalXCFramework" version="5.0.2" addToAllTargets="true" />
     </iosPods>
 </dependencies>

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeNotifications.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeNotifications.mm
@@ -70,7 +70,6 @@ typedef void (*ClickListenerDelegate)(const char* notification, const char* resu
     if (self = [super init]) {
         [OneSignal.Notifications addPermissionObserver:self];
         [OneSignal.Notifications addForegroundLifecycleListener:self];
-        [OneSignal.Notifications addClickListener:self];
 
         _willDisplayEvents = [NSMutableDictionary new];
     }
@@ -161,5 +160,7 @@ extern "C" {
 
     void _notificationsSetClickCallback(ClickListenerDelegate callback) {
         [[OneSignalNotificationsObserver sharedNotificationsObserver] setClickDelegate:callback];
+        
+        [OneSignal.Notifications addClickListener:[OneSignalNotificationsObserver sharedNotificationsObserver]];
     }
 }

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/UIApplication+OneSignalUnity.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/UIApplication+OneSignalUnity.mm
@@ -97,7 +97,7 @@ static bool swizzled = false;
 - (BOOL)oneSignalApplication:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [OneSignalWrapper setSdkType:@"unity"];
     [OneSignalWrapper setSdkVersion:@"050002"];
-    [OneSignal setLaunchOptions:launchOptions];
+    [OneSignal initialize:nil withLaunchOptions:launchOptions];
 
     if ([self respondsToSelector:@selector(oneSignalApplication:didFinishLaunchingWithOptions:)])
         return [self oneSignalApplication:application didFinishLaunchingWithOptions:launchOptions];

--- a/com.onesignal.unity.ios/Runtime/iOSNotificationsManager.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSNotificationsManager.cs
@@ -56,14 +56,16 @@ namespace OneSignalSDK.iOS.Notifications {
         public event EventHandler<NotificationWillDisplayEventArgs> ForegroundWillDisplay;
         public event EventHandler<NotificationPermissionChangedEventArgs> PermissionChanged;
 
-        private bool _clickDelegate;
+        // Only set the native listner once
+        private bool _clickNativeListenerSet;
+
         private EventHandler<NotificationClickEventArgs> _clicked;
         public event EventHandler<NotificationClickEventArgs> Clicked {
             add {
-                // only add one click listener
-                if (!_clickDelegate) {
-                    _clicked += value;
-                    _clickDelegate = true;
+                _clicked += value;
+
+                if (!_clickNativeListenerSet) {
+                    _clickNativeListenerSet = true;
                     _notificationsSetClickCallback(_onClicked);
                 }
             }

--- a/com.onesignal.unity.ios/Runtime/iOSNotificationsManager.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSNotificationsManager.cs
@@ -48,7 +48,7 @@ namespace OneSignalSDK.iOS.Notifications {
         [DllImport("__Internal")] private static extern void _notificationsWillDisplayEventPreventDefault(string notificationId);
         [DllImport("__Internal")] private static extern void _notificationsSetClickCallback(ClickListenerDelegate callback);
 
-        public delegate void PermissionListenerDelegate(bool permission);
+        private delegate void PermissionListenerDelegate(bool permission);
         private delegate void WillDisplayListenerDelegate(string notification);
         private delegate void ClickListenerDelegate(string notification, string resultActionId, string resultUrl);
         private delegate void BooleanResponseDelegate(int hashCode, bool response);


### PR DESCRIPTION
# Description
## One Line Summary
Fixes iOS notifications clicked event to fire when the app was cold started from clicking a notification.

## Details
### Motivation
Fixes https://github.com/OneSignal/OneSignal-Unity-SDK/issues/638 iOS bug where Notifications.Clicked event is set but does not fire when clicking the notification cold starts the app.

# Testing
## Manual testing
Tested clicking on notifications when the app in the foreground, background, and closed, app build with Unity 2021.3.16f1 of the OneSignal example app on a physical iPhone 12 with iOS 15.5.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/641)
<!-- Reviewable:end -->
