### PR TITLE
[Fix] iOS bitcode build error

### DIFF
--- a/MIGRATION_GUIDE_v3_to_v5.md
+++ b/MIGRATION_GUIDE_v3_to_v5.md
@@ -250,7 +250,7 @@ The debug namespace is accessible via `OneSignal.Debug` and provides access to d
     - We will be introducing JWT in a follow up release
 
 # Troubleshooting
-
+## Android
 ```
 Assets/OneSignal/Example/OneSignalExampleBehaviou.cs: error CS0246: The type or namespace name '...' could not be found (are you missing a using directive or an assembly reference?)
 ```
@@ -284,3 +284,12 @@ Execution failed for task ':launcher:mergeReleaseJavaResource'.
    - Custom Main Gradle Template
    - Custom Gradle Properties Template
 2. Resolve Android dependencies with EDM4U at **Assets > External Dependency Manager > Android Resolver > Force Resolve**
+
+## iOS
+**Build error**
+```
+'/Users/.../Library/Developer/Xcode/DerivedData/Unity-iPhone-.../Build/Products/ReleaseForRunning-iphoneos/XCFrameworkIntermediates/OneSignalXCFramework/OneSignalCore/OneSignalCore.framework/OneSignalCore' does not contain bitcode. You must rebuild it with bitcode enabled (Xcode setting ENABLE_BITCODE), obtain an updated library from the vendor, or disable bitcode for this target. file '/Users/.../Library/Developer/Xcode/DerivedData/Unity-iPhone-.../Build/Products/ReleaseForRunning-iphoneos/XCFrameworkIntermediates/OneSignalXCFramework/OneSignalCore/OneSignalCore.framework/OneSignalCore' for architecture arm64
+```
+
+1. For each target, select the **Build Settings** tab
+2. Set **Enable Bitcode** to **No**

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sending VSAttribution data from the editor
 - iOS notifications clicked event firing if the app was cold started from clicking a notification
 - ClassNotFoundException: com.onesignal.OneSignal for Android builds with minify enabled. You must run the "Copy Android plugin to Assets" step in **Window > OneSignal SDK Setup**.
+- Disabled bitcode to avoid iOS build error
 
 ## [5.0.2]
 ### Fixed

--- a/OneSignalExample/Assets/OneSignal/MIGRATION_GUIDE_v3_to_v5.md
+++ b/OneSignalExample/Assets/OneSignal/MIGRATION_GUIDE_v3_to_v5.md
@@ -250,7 +250,7 @@ The debug namespace is accessible via `OneSignal.Debug` and provides access to d
     - We will be introducing JWT in a follow up release
 
 # Troubleshooting
-
+## Android
 ```
 Assets/OneSignal/Example/OneSignalExampleBehaviou.cs: error CS0246: The type or namespace name '...' could not be found (are you missing a using directive or an assembly reference?)
 ```
@@ -284,3 +284,12 @@ Execution failed for task ':launcher:mergeReleaseJavaResource'.
    - Custom Main Gradle Template
    - Custom Gradle Properties Template
 2. Resolve Android dependencies with EDM4U at **Assets > External Dependency Manager > Android Resolver > Force Resolve**
+
+## iOS
+**Build error**
+```
+'/Users/.../Library/Developer/Xcode/DerivedData/Unity-iPhone-.../Build/Products/ReleaseForRunning-iphoneos/XCFrameworkIntermediates/OneSignalXCFramework/OneSignalCore/OneSignalCore.framework/OneSignalCore' does not contain bitcode. You must rebuild it with bitcode enabled (Xcode setting ENABLE_BITCODE), obtain an updated library from the vendor, or disable bitcode for this target. file '/Users/.../Library/Developer/Xcode/DerivedData/Unity-iPhone-.../Build/Products/ReleaseForRunning-iphoneos/XCFrameworkIntermediates/OneSignalXCFramework/OneSignalCore/OneSignalCore.framework/OneSignalCore' for architecture arm64
+```
+
+1. For each target, select the **Build Settings** tab
+2. Set **Enable Bitcode** to **No**

--- a/OneSignalExample/Assets/OneSignal/README.md
+++ b/OneSignalExample/Assets/OneSignal/README.md
@@ -119,6 +119,8 @@ After building in Unity and exporting the XCode project follow these steps:
 
 6. **App Groups** should now be provisioned for you going forward for your iOS bundle id, even on clean builds.
 
+7. Make sure all **Targets** have **Enable Bitcode** set to **No** in **Build Settings**.
+
 ### Android
 Most of the Android setup was already handled during installation!
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ After building in Unity and exporting the XCode project follow these steps:
 
 6. **App Groups** should now be provisioned for you going forward for your iOS bundle id, even on clean builds.
 
+7. Make sure all **Targets** have **Enable Bitcode** set to **No** in **Build Settings**.
+
 ### Android
 In the Unity editor:
 

--- a/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
+++ b/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
@@ -111,6 +111,14 @@ namespace OneSignalSDK.iOS {
             // Add the service extension
             AddNotificationServiceExtension();
 
+            // Unity Tests
+            var unityTests = _project.TargetGuidByName(PBXProject.GetUnityTestTargetName());
+            _project.SetBuildProperty(unityTests, "ENABLE_BITCODE", "NO");
+
+            // Unity Framework
+            var unityFramework = _project.GetUnityFrameworkTargetGuid();
+            _project.SetBuildProperty(unityFramework, "ENABLE_BITCODE", "NO");
+
             // Save the project back out
             File.WriteAllText(_projectPath, _project.WriteToString());
         }
@@ -152,6 +160,8 @@ namespace OneSignalSDK.iOS {
             var targetGuid = _project.GetMainTargetGuid();
             var targetName = _project.GetMainTargetName();
 
+            _project.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
+
             var entitlementsPath = GetEntitlementsPath(targetGuid, targetName);
             var projCapability = new ProjectCapabilityManager(_projectPath, entitlementsPath, targetName);
 
@@ -191,6 +201,7 @@ namespace OneSignalSDK.iOS {
             _project.SetBuildProperty(extensionGuid, "SWIFT_VERSION", "5.0");
             _project.SetBuildProperty(extensionGuid, "ARCHS", "arm64");
             _project.SetBuildProperty(extensionGuid, "DEVELOPMENT_TEAM", PlayerSettings.iOS.appleDeveloperTeamID);
+            _project.SetBuildProperty(extensionGuid, "ENABLE_BITCODE", "NO");
 
             _project.AddBuildProperty(extensionGuid, "LIBRARY_SEARCH_PATHS",
                 $"$(PROJECT_DIR)/Libraries/{PluginLibrariesPath.Replace("\\", "/")}");

--- a/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
+++ b/com.onesignal.unity.ios/Editor/BuildPostProcessor.cs
@@ -111,13 +111,7 @@ namespace OneSignalSDK.iOS {
             // Add the service extension
             AddNotificationServiceExtension();
 
-            // Unity Tests
-            var unityTests = _project.TargetGuidByName(PBXProject.GetUnityTestTargetName());
-            _project.SetBuildProperty(unityTests, "ENABLE_BITCODE", "NO");
-
-            // Unity Framework
-            var unityFramework = _project.GetUnityFrameworkTargetGuid();
-            _project.SetBuildProperty(unityFramework, "ENABLE_BITCODE", "NO");
+            DisableBitcode();
 
             // Save the project back out
             File.WriteAllText(_projectPath, _project.WriteToString());
@@ -159,8 +153,6 @@ namespace OneSignalSDK.iOS {
         private void AddProjectCapabilities() {
             var targetGuid = _project.GetMainTargetGuid();
             var targetName = _project.GetMainTargetName();
-
-            _project.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
 
             var entitlementsPath = GetEntitlementsPath(targetGuid, targetName);
             var projCapability = new ProjectCapabilityManager(_projectPath, entitlementsPath, targetName);
@@ -292,6 +284,20 @@ namespace OneSignalSDK.iOS {
             }
             
             File.WriteAllText(podfilePath, podfile);
+        }
+
+        private void DisableBitcode() {
+            // Main
+            var targetGuid = _project.GetMainTargetGuid();
+            _project.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
+
+            // Unity Tests
+            var unityTests = _project.TargetGuidByName(PBXProject.GetUnityTestTargetName());
+            _project.SetBuildProperty(unityTests, "ENABLE_BITCODE", "NO");
+
+            // Unity Framework
+            var unityFramework = _project.GetUnityFrameworkTargetGuid();
+            _project.SetBuildProperty(unityFramework, "ENABLE_BITCODE", "NO");
         }
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Fixes iOS "does not contain bitcode" build error by disabling bitcode

## Details

### Motivation
Prevent iOS builds from failing with default "Enable Bitcode" value and documents setting "Enable Bitcode" to "No".

# Testing
## Manual testing
Tested OneSignal initialization, app build with Unity 2022.3.10f1 of the OneSignal example app on a physical iPhone 12 with iOS 15.5.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/645)
<!-- Reviewable:end -->
