### PR TITLE
[Fix] Documentation Nit

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `InstallEdm4uStep` now imports version [1.2.177](https://github.com/googlesamples/unity-jar-resolver/releases/tag/v1.2.177) of [EDM4U](https://github.com/googlesamples/unity-jar-resolver)
 - Updated included Android SDK to [5.0.2](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.0.2)
 - Updated included iOS SDK to [5.0.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.0.2)
+- `OneSignalConfig.plugin` has been changed to `OneSignalConfig.androidlib`. Run the "Copy Android plugin to Assets" step in **Window > OneSignal SDK Setup** to migrate. Custom notification icons are now located in `Assets/Plugins/Android/OneSignalConfig.androidlib/src/main/res`
 ### Fixed
 - Sending VSAttribution data from the editor
 - iOS notifications clicked event firing if the app was cold started from clicking a notification

--- a/OneSignalExample/Assets/OneSignal/README.md
+++ b/OneSignalExample/Assets/OneSignal/README.md
@@ -130,7 +130,7 @@ After building in Unity and exporting the XCode project follow these steps:
 
 Most of the Android setup was already handled during installation!
 
-The only thing remaining is to setup your own notification icons. You can do this be replacing the example icons located at `Assets/Plugins/Android/OneSignalConfig.androidlib` 
+The only thing remaining is to setup your own notification icons. You can do this be replacing the example icons located at `Assets/Plugins/Android/OneSignalConfig.androidlib/src/main/res` 
 with your own. There is a complete guide for this [in the plugin's README](com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/README.md). See our 
 [Customize Notification Icons](https://documentation.onesignal.com/docs/customize-notification-icons) page for additional details.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ After building in Unity and exporting the XCode project follow these steps:
 
 Most of the Android setup was already handled during installation!
 
-The only thing remaining is to setup your own notification icons. You can do this be replacing the example icons located at `Assets/Plugins/Android/OneSignalConfig.androidlib` 
+The only thing remaining is to setup your own notification icons. You can do this be replacing the example icons located at `Assets/Plugins/Android/OneSignalConfig.androidlib/src/main/res` 
 with your own. There is a complete guide for this [in the plugin's README](com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/README.md). See our 
 [Customize Notification Icons](https://documentation.onesignal.com/docs/customize-notification-icons) page for additional details.
 


### PR DESCRIPTION
# Description
## One Line Summary
Update documentation to make it clearer that `OneSignalConfig.plugin` has been changed to `OneSignalConfig.androidlib`

## Details

### Motivation
Make it clearer that custom notification icons are now located in `Assets/Plugins/Android/OneSignalConfig.androidlib/src/main/res` and that users should run the "Copy Android plugin to Assets" step in **Window > OneSignal SDK Setup** to migrate. 

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/649)
<!-- Reviewable:end -->
