### PR TITLE
[Fix] Include OneSignalConfig.androidlib meta files

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Included meta files in OneSignalConfig.androidlib to prevent asset from being ignored
+
 ## [5.0.4]
 ### Changed
 - Updated included Android SDK to [5.0.3](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.0.3)

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/AndroidManifest.xml.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/AndroidManifest.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 235813143c0084587adc103ea7388e44
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/README.md.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e599536f8e098493d8ba2e242b655b52
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/build.gradle.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/build.gradle.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 66208aebb9b9a4fb69d33c19475a689b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/consumer-proguard.pro.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/consumer-proguard.pro.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a228b277bb5114323a815f318bffc96b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b3bd822a1f1814d5cac76cc10e3acbd6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e774cf8b768354b7099e3c97e7be22b2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 59ef453dfcf3d4b08b29c1688e540c52
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-hdpi.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-hdpi.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2e69d20ade0643b99ac7f426bc24d9d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-hdpi/ic_stat_onesignal_default.png.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-hdpi/ic_stat_onesignal_default.png.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 005e9af4b102442faaf2ba8ee7adde4c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-mdpi.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-mdpi.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 50395df7d66fc44b7b034afc527d23c6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-mdpi/ic_stat_onesignal_default.png.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-mdpi/ic_stat_onesignal_default.png.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a2921732128cd4864a11cbeba29625a8
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xhdpi.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xhdpi.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 780926c49d733476989a61871f09934e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xhdpi/ic_stat_onesignal_default.png.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xhdpi/ic_stat_onesignal_default.png.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fa7d030d8480a4e5e8377eb585dcd024
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xxhdpi.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xxhdpi.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 13fd904f2b75e425c963d3b95c1538be
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xxhdpi/ic_stat_onesignal_default.png.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xxhdpi/ic_stat_onesignal_default.png.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6e8b000fe7b4f48139c16fc4218aaef9
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xxxhdpi.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xxxhdpi.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5ce690e195a1146489d942aeb0d24320
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xxxhdpi/ic_onesignal_large_icon_default.png.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xxxhdpi/ic_onesignal_large_icon_default.png.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e0c41d7034e9845ae9ed815fed01124b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xxxhdpi/ic_stat_onesignal_default.png.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/drawable-xxxhdpi/ic_stat_onesignal_default.png.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 379a80a88430b466db534453bd1d13ea
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/raw.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/raw.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ee375cecf3df46749d04a4626059689
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/raw/notification.wav.meta
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/src/main/res/raw/notification.wav.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cd041c5eb302d47b58e48f38c4e4eb03
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/SetupSteps/ExportAndroidResourcesStep.cs
+++ b/com.onesignal.unity.android/Editor/SetupSteps/ExportAndroidResourcesStep.cs
@@ -50,6 +50,7 @@ namespace OneSignalSDK {
 
             var packagePaths = Directory.GetFiles(_pluginPackagePath, "*", SearchOption.AllDirectories)
                .Select(path => path.Remove(0, path.LastIndexOf(_pluginName, StringComparison.InvariantCulture)));
+            packagePaths = packagePaths.Where(file => !file.EndsWith(".meta"));
 
             var exportPaths = Directory.GetFiles(_pluginExportPath, "*", SearchOption.AllDirectories)
                .Select(path => path.Remove(0, path.LastIndexOf(_pluginName, StringComparison.InvariantCulture)));
@@ -69,8 +70,9 @@ namespace OneSignalSDK {
             MigratePluginToAndroidlib();
 
             var files = Directory.GetFiles(_pluginPackagePath, "*", SearchOption.AllDirectories);
+            var filteredFiles = files.Where(file => !file.EndsWith(".meta"));
 
-            foreach (var file in files) {
+            foreach (var file in filteredFiles) {
                 var trimmedPath    = file.Remove(0, _pluginPackagePath.Length + 1);
                 var fileExportPath = Path.Combine(_pluginExportPath, trimmedPath);
                 var containingPath = fileExportPath.Remove(fileExportPath.LastIndexOf(Path.DirectorySeparatorChar));


### PR DESCRIPTION
# Description
## One Line Summary
Includes .meta files in OneSignalConfig.androidlib to prevent asset from being ignored

## Details

### Motivation
Fixes compile time errors in Android package - all files in `Packages/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/`:
```
Packages/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/AndroidManifest.xml has no meta file, but it's in an immutable folder. The asset will be ignored.
```

### Scope
Affects Unity Editor 2021 versions. Reproducible in 2021.3 but I was unable to reproduce in 2022.3.10.

Unity made a change where meta files don't need to be included in plugins for newer versions:
https://forum.unity.com/threads/loadable-plugin-directory-import-behaviour-change-androidlib-bundle-framework-and-plugin.1381113/

It looks like the change does not apply to 2021 because of the compile errors, so it looks like we need to include meta files in our OneSignalConfig.androidlib for 2021 support.

# Testing
## Manual testing
Tested OneSignal initialization, app build with Unity 2021.3.0f1 and 2022.3.10f1 of the OneSignal example app on a emulated Pixel 4 with Android 12.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item