### PR TITLE
[Fix] OneSignal SDK Setup package download url

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Included meta files in OneSignalConfig.androidlib to prevent asset from being ignored
+- Package download url in the "Sync example code bundle package" step from the OneSignal SDK Setup
 
 ## [5.0.4]
 ### Changed

--- a/com.onesignal.unity.core/Editor/SetupSteps/SyncCodeBundleStep.cs
+++ b/com.onesignal.unity.core/Editor/SetupSteps/SyncCodeBundleStep.cs
@@ -78,7 +78,7 @@ namespace OneSignalSDK {
         private static string _bundleVersion => File.ReadAllText(_versionPath);
 
         private static string _onesignalUnityPackageDownloadUrl
-            => $"https://github.com/OneSignal/OneSignal-Unity-SDK/blob/{_sdkVersion}/OneSignal-v{_sdkVersion}.unitypackage";
+            => $"https://github.com/OneSignal/OneSignal-Unity-SDK/releases/download/{_sdkVersion}/OneSignal-v{_sdkVersion}.unitypackage";
 
         private static readonly string _packagePath = Path.Combine("Packages", "com.onesignal.unity.core");
         private static readonly string _packageJsonPath = Path.Combine(_packagePath, "package.json");


### PR DESCRIPTION
# Description
## One Line Summary
Fixes package download url in the "Sync example code bundle package" step from the OneSignal SDK Setup

## Details

### Motivation
Fixes `HTTP:1.1 404 Not Found` error when running the "Sync example code bundle package" setup step

# Testing
## Manual testing
Tested running the "Sync example code bundle package" OneSignal SDK Setup step in the Unity Editor

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/657)
<!-- Reviewable:end -->
