### PR TITLE
[Fix] Add prefix to Obj-C methods

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Duplicate symbol errors when building with other iOS plugins
+
 ## [5.0.5]
 ### Fixed
 - Included meta files in OneSignalConfig.androidlib to prevent asset from being ignored

--- a/com.onesignal.unity.ios/Runtime/OneSignaliOS.cs
+++ b/com.onesignal.unity.ios/Runtime/OneSignaliOS.cs
@@ -48,12 +48,12 @@ using OneSignalSDK.iOS.LiveActivities;
 
 namespace OneSignalSDK.iOS {
     public sealed partial class OneSignaliOS : OneSignalPlatform {
-        [DllImport("__Internal")] private static extern void _setConsentGiven(bool consent);
-        [DllImport("__Internal")] private static extern void _setConsentRequired(bool required);
-        [DllImport("__Internal")] private static extern void _initialize(string appId);
-        [DllImport("__Internal")] private static extern void _login(string externalId);
-        [DllImport("__Internal")] private static extern void _loginWithJwtBearerToken(string externalId, string jwtBearerToken);
-        [DllImport("__Internal")] private static extern void _logout();
+        [DllImport("__Internal")] private static extern void _oneSignalSetConsentGiven(bool consent);
+        [DllImport("__Internal")] private static extern void _oneSignalSetConsentRequired(bool required);
+        [DllImport("__Internal")] private static extern void _oneSignalInitialize(string appId);
+        [DllImport("__Internal")] private static extern void _oneSignalLogin(string externalId);
+        [DllImport("__Internal")] private static extern void _oneSignalLoginWithJwtBearerToken(string externalId, string jwtBearerToken);
+        [DllImport("__Internal")] private static extern void _oneSignalLogout();
 
         private iOSUserManager _user;
         private iOSSessionManager _session;
@@ -105,15 +105,15 @@ namespace OneSignalSDK.iOS {
         }
 
         public override bool ConsentGiven {
-            set => _setConsentGiven(value);
+            set => _oneSignalSetConsentGiven(value);
         }
 
         public override bool ConsentRequired {
-            set => _setConsentRequired(value);
+            set => _oneSignalSetConsentRequired(value);
         }
 
         public override void Initialize(string appId) {
-            _initialize(appId);
+            _oneSignalInitialize(appId);
 
             if (_inAppMessages == null) {
                 _inAppMessages = new iOSInAppMessagesManager();
@@ -147,14 +147,14 @@ namespace OneSignalSDK.iOS {
 
         public override void Login(string externalId, string jwtBearerToken = null) {
             if (jwtBearerToken == null) {
-                _login(externalId);
+                _oneSignalLogin(externalId);
             } else {
-                _loginWithJwtBearerToken(externalId, jwtBearerToken);
+                _oneSignalLoginWithJwtBearerToken(externalId, jwtBearerToken);
             }
         }
 
         public override void Logout() {
-            _logout();
+            _oneSignalLogout();
         }
     }
 }

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalBridgeUtil.h
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalBridgeUtil.h
@@ -29,8 +29,8 @@
 
 @interface OneSignalBridgeUtil : NSObject
 
-const char* jsonStringFromDictionary(NSDictionary *dictionary);
-NSDictionary* dictionaryFromJsonString(const char* jsonString);
-NSArray* arrayFromJsonString(const char* jsonString);
+const char* oneSignalJsonStringFromDictionary(NSDictionary *dictionary);
+NSDictionary* oneSignalDictionaryFromJsonString(const char* jsonString);
+NSArray* oneSignalArrayFromJsonString(const char* jsonString);
 
 @end

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalBridgeUtil.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalBridgeUtil.mm
@@ -29,7 +29,7 @@
 
 @implementation OneSignalBridgeUtil
 
-const char* jsonStringFromDictionary(NSDictionary *dictionary) {
+const char* oneSignalJsonStringFromDictionary(NSDictionary *dictionary) {
     NSError *error;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:&error];
     NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
@@ -37,7 +37,7 @@ const char* jsonStringFromDictionary(NSDictionary *dictionary) {
 }
 
 template <typename TObj>
-TObj objFromJsonString(const char* jsonString) {
+TObj oneSignalObjFromJsonString(const char* jsonString) {
     NSData* jsonData = [[NSString stringWithUTF8String:jsonString] dataUsingEncoding:NSUTF8StringEncoding];
     NSError* error = nil;
     TObj arr = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
@@ -48,12 +48,12 @@ TObj objFromJsonString(const char* jsonString) {
     return arr;
 }
 
-NSDictionary* dictionaryFromJsonString(const char* jsonString) {
-    return objFromJsonString<NSDictionary*>(jsonString);
+NSDictionary* oneSignalDictionaryFromJsonString(const char* jsonString) {
+    return oneSignalObjFromJsonString<NSDictionary*>(jsonString);
 }
 
-NSArray* arrayFromJsonString(const char* jsonString) {
-    return objFromJsonString<NSArray*>(jsonString);
+NSArray* oneSignalArrayFromJsonString(const char* jsonString) {
+    return oneSignalObjFromJsonString<NSArray*>(jsonString);
 }
 
 @end

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridge.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridge.mm
@@ -41,27 +41,27 @@
  */
 
 extern "C" {
-    void _initialize(const char* appId) {
+    void _oneSignalInitialize(const char* appId) {
         [OneSignal initialize:TO_NSSTRING(appId) withLaunchOptions:nil];
     }
 
-    void _login(const char* externalId) {
+    void _oneSignalLogin(const char* externalId) {
         [OneSignal login:TO_NSSTRING(externalId)];
     }
 
-    void _loginWithJwtBearerToken(const char* externalId, const char* token) {
+    void _oneSignalLoginWithJwtBearerToken(const char* externalId, const char* token) {
         [OneSignal login:TO_NSSTRING(externalId) withToken:TO_NSSTRING(token)];
     }
 
-    void _logout() {
+    void _oneSignalLogout() {
         [OneSignal logout];
     }
 
-    void _setConsentGiven(bool consent) {
+    void _oneSignalSetConsentGiven(bool consent) {
         [OneSignal setConsentGiven:consent];
     }
 
-    void _setConsentRequired(bool required) {
+    void _oneSignalSetConsentRequired(bool required) {
         [OneSignal setConsentRequired:required];
     }
 }

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeDebug.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeDebug.mm
@@ -30,11 +30,11 @@
 #import <OneSignalFramework/OneSignalFramework.h>
 
 extern "C" {
-    void _debugSetLogLevel(int logLevel) {
+    void _oneSignalDebugSetLogLevel(int logLevel) {
         [OneSignal.Debug setLogLevel:(ONE_S_LOG_LEVEL) logLevel];
     }
 
-    void _debugSetAlertLevel(int alertLevel) {
+    void _oneSignalDebugSetAlertLevel(int alertLevel) {
         [OneSignal.Debug setAlertLevel:(ONE_S_LOG_LEVEL) alertLevel];
     }
 }

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeInAppMessages.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeInAppMessages.mm
@@ -97,8 +97,8 @@ typedef void (*ClickListenerDelegate)(const char* message, const char* result, i
 
 - (void)onClickInAppMessage:(OSInAppMessageClickEvent * _Nonnull)event {
     if (_clickDelegate != nil) {
-        auto message = jsonStringFromDictionary([[event message] jsonRepresentation]);
-        auto result = jsonStringFromDictionary([[event result] jsonRepresentation]);
+        auto message = oneSignalJsonStringFromDictionary([[event message] jsonRepresentation]);
+        auto result = oneSignalJsonStringFromDictionary([[event result] jsonRepresentation]);
         _clickDelegate(message, result, event.result.urlTarget);
     }
 }
@@ -110,55 +110,55 @@ typedef void (*ClickListenerDelegate)(const char* message, const char* result, i
  */
 
 extern "C" {
-    void _inAppMessagesSetWillDisplayCallback(StringListenerDelegate callback) {
+    void _oneSignalInAppMessagesSetWillDisplayCallback(StringListenerDelegate callback) {
         [[OneSignalInAppMessagesObserver sharedInAppMessagesObserver] setWillDisplayDelegate:callback];
     }
 
-    void _inAppMessagesSetDidDisplayCallback(StringListenerDelegate callback) {
+    void _oneSignalInAppMessagesSetDidDisplayCallback(StringListenerDelegate callback) {
         [[OneSignalInAppMessagesObserver sharedInAppMessagesObserver] setDidDisplayDelegate:callback];
     }
 
-    void _inAppMessagesSetWillDismissCallback(StringListenerDelegate callback) {
+    void _oneSignalInAppMessagesSetWillDismissCallback(StringListenerDelegate callback) {
         [[OneSignalInAppMessagesObserver sharedInAppMessagesObserver] setWillDismissDelegate:callback];
     }
 
-    void _inAppMessagesSetDidDismissCallback(StringListenerDelegate callback) {
+    void _oneSignalInAppMessagesSetDidDismissCallback(StringListenerDelegate callback) {
         [[OneSignalInAppMessagesObserver sharedInAppMessagesObserver] setDidDismissDelegate:callback];
     }
 
-    void _inAppMessagesSetClickCallback(ClickListenerDelegate callback) {
+    void _oneSignalInAppMessagesSetClickCallback(ClickListenerDelegate callback) {
         [[OneSignalInAppMessagesObserver sharedInAppMessagesObserver] setClickDelegate:callback];
     }
 
-    void _inAppMessagesSetPaused(bool paused) {
+    void _oneSignalInAppMessagesSetPaused(bool paused) {
         [OneSignal.InAppMessages paused:paused];
     }
 
-    bool _inAppMessagesGetPaused() {
+    bool _oneSignalInAppMessagesGetPaused() {
         return [OneSignal.InAppMessages paused];
     }
 
-    void _inAppMessagesAddTrigger(const char* key, const char* value) {
+    void _oneSignalInAppMessagesAddTrigger(const char* key, const char* value) {
         [OneSignal.InAppMessages addTrigger:TO_NSSTRING(key) withValue:TO_NSSTRING(value)];
     }
 
-    void _inAppMessagesAddTriggers(const char* triggersJson) {
-        NSDictionary *triggers = dictionaryFromJsonString(triggersJson);
+    void _oneSignalInAppMessagesAddTriggers(const char* triggersJson) {
+        NSDictionary *triggers = oneSignalDictionaryFromJsonString(triggersJson);
 
         [OneSignal.InAppMessages addTriggers:triggers];
     }
 
-    void _inAppMessagesRemoveTrigger(const char* key) {
+    void _oneSignalInAppMessagesRemoveTrigger(const char* key) {
         [OneSignal.InAppMessages removeTrigger:TO_NSSTRING(key)];
     }
 
-    void _inAppMessagesRemoveTriggers(const char* triggersJson) {
-        NSArray *triggers = arrayFromJsonString(triggersJson);
+    void _oneSignalInAppMessagesRemoveTriggers(const char* triggersJson) {
+        NSArray *triggers = oneSignalArrayFromJsonString(triggersJson);
 
         [OneSignal.InAppMessages removeTriggers:triggers];
     }
 
-    void _inAppMessagesClearTriggers() {
+    void _oneSignalInAppMessagesClearTriggers() {
         [OneSignal.InAppMessages clearTriggers];
     }
 }

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeLiveActivities.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeLiveActivities.mm
@@ -43,14 +43,14 @@ typedef void (*BooleanResponseDelegate)(int hashCode, bool response);
  */
 
 extern "C" {
-    void _enterLiveActivity(const char* activityId, const char* token, int hashCode, BooleanResponseDelegate callback) {
+    void _oneSignalEnterLiveActivity(const char* activityId, const char* token, int hashCode, BooleanResponseDelegate callback) {
         [OneSignal.LiveActivities enter:TO_NSSTRING(activityId)
                         withToken:TO_NSSTRING(token)
                         withSuccess:^(NSDictionary *result) { CALLBACK(YES); }
                         withFailure:^(NSError *error) { CALLBACK(NO); }];
     }
 
-    void _exitLiveActivity(const char* activityId, int hashCode, BooleanResponseDelegate callback) {
+    void _oneSignalExitLiveActivity(const char* activityId, int hashCode, BooleanResponseDelegate callback) {
         [OneSignal.LiveActivities exit:TO_NSSTRING(activityId)
                         withSuccess:^(NSDictionary *result) { CALLBACK(YES); }
                         withFailure:^(NSError *error) { CALLBACK(NO); }];

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeLocation.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeLocation.mm
@@ -30,15 +30,15 @@
 #import <OneSignalFramework/OneSignalFramework.h>
 
 extern "C" {
-    bool _locationGetIsShared() {
+    bool _oneSignalLocationGetIsShared() {
         return [OneSignal.Location isShared];
     }
 
-    void _locationSetIsShared(bool shared) {
+    void _oneSignalLocationSetIsShared(bool shared) {
         [OneSignal.Location setShared:shared];
     }
 
-    void _locationRequestPermission() {
+    void _oneSignalLocationRequestPermission() {
         [OneSignal.Location requestPermission];
     }
 }

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeNotifications.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeNotifications.mm
@@ -118,47 +118,47 @@ typedef void (*ClickListenerDelegate)(const char* notification, const char* resu
  */
 
 extern "C" {
-    bool _notificationsGetPermission() {
+    bool _oneSignalNotificationsGetPermission() {
         return [OneSignal.Notifications permission];
     }
 
-    bool _notificationsGetCanRequestPermission() {
+    bool _oneSignalNotificationsGetCanRequestPermission() {
         return [OneSignal.Notifications canRequestPermission];
     }
 
-    int _notificationsGetPermissionNative() {
+    int _oneSignalNotificationsGetPermissionNative() {
         return [OneSignal.Notifications permissionNative];
     }
 
-    void _notificationsClearAll() {
+    void _oneSignalNotificationsClearAll() {
         [OneSignal.Notifications clearAll];
     }
 
-    void _notificationsRequestPermission(bool fallbackToSettings, int hashCode, BooleanResponseDelegate callback) {
+    void _oneSignalNotificationsRequestPermission(bool fallbackToSettings, int hashCode, BooleanResponseDelegate callback) {
         [OneSignal.Notifications requestPermission:^(BOOL accepted) {
             CALLBACK(accepted);
         } fallbackToSettings:fallbackToSettings];
     }
 
-    void _notificationsAddPermissionObserver(PermissionListenerDelegate callback) {
+    void _oneSignalNotificationsAddPermissionObserver(PermissionListenerDelegate callback) {
         [[OneSignalNotificationsObserver sharedNotificationsObserver] setPermissionDelegate:callback];
     }
 
-    void _notificationsSetForegroundWillDisplayCallback(WillDisplayListenerDelegate callback) {
+    void _oneSignalNotificationsSetForegroundWillDisplayCallback(WillDisplayListenerDelegate callback) {
         [[OneSignalNotificationsObserver sharedNotificationsObserver] setWillDisplayDelegate:callback];
     }
 
-    void _notificationsWillDisplayEventPreventDefault(const char* notifcationId) {
+    void _oneSignalNotificationsWillDisplayEventPreventDefault(const char* notifcationId) {
         NSString *key = [NSString stringWithUTF8String:notifcationId];
         [[OneSignalNotificationsObserver sharedNotificationsObserver] notificationsWillDisplayEventPreventDefault:key];
     }
 
-    void _notificationsDisplay(const char* notifcationId) {
+    void _oneSignalNotificationsDisplay(const char* notifcationId) {
         NSString *key = [NSString stringWithUTF8String:notifcationId];
         [[OneSignalNotificationsObserver sharedNotificationsObserver] notificationsDisplay:key];
     }
 
-    void _notificationsSetClickCallback(ClickListenerDelegate callback) {
+    void _oneSignalNotificationsSetClickCallback(ClickListenerDelegate callback) {
         [[OneSignalNotificationsObserver sharedNotificationsObserver] setClickDelegate:callback];
         
         [OneSignal.Notifications addClickListener:[OneSignalNotificationsObserver sharedNotificationsObserver]];

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeSession.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeSession.mm
@@ -40,15 +40,15 @@
  */
 
 extern "C" {
-    void _sessionAddOutcome(const char* name) {
+    void _oneSignalSessionAddOutcome(const char* name) {
         [OneSignal.Session addOutcome:TO_NSSTRING(name)];
     }
 
-    void _sessionAddUniqueOutcome(const char* name) {
+    void _oneSignalSessionAddUniqueOutcome(const char* name) {
         [OneSignal.Session addUniqueOutcome:TO_NSSTRING(name)];
     }
 
-    void _sessionAddOutcomeWithValue(const char* name, float value) {
+    void _oneSignalSessionAddOutcomeWithValue(const char* name, float value) {
         [OneSignal.Session addOutcomeWithValue:TO_NSSTRING(name)
                                          value:@(value)];
     }

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeUser.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeUser.mm
@@ -70,8 +70,8 @@ typedef void (*StateListenerDelegate)(const char* current, const char* previous)
 
 - (void)onPushSubscriptionDidChangeWithState:(OSPushSubscriptionChangedState*)state {
     if (_pushSubscriptionDelegate != nil) {
-        auto curr = jsonStringFromDictionary([[state current] jsonRepresentation]);
-        auto prev = jsonStringFromDictionary([[state previous] jsonRepresentation]);
+        auto curr = oneSignalJsonStringFromDictionary([[state current] jsonRepresentation]);
+        auto prev = oneSignalJsonStringFromDictionary([[state previous] jsonRepresentation]);
         _pushSubscriptionDelegate(curr, prev);
     }
 }
@@ -84,27 +84,27 @@ typedef void (*StateListenerDelegate)(const char* current, const char* previous)
  */
 
 extern "C" {
-    void _userSetLanguage(const char* languageCode) {
+    void _oneSignalUserSetLanguage(const char* languageCode) {
         [OneSignal.User setLanguage:TO_NSSTRING(languageCode)];
     }
 
-    void _userAddAlias(const char* aliasLabel, const char* aliasId) {
+    void _oneSignalUserAddAlias(const char* aliasLabel, const char* aliasId) {
         [OneSignal.User addAliasWithLabel:TO_NSSTRING(aliasLabel)
                                        id:TO_NSSTRING(aliasId)];
     }
 
-    void _userAddAliases(const char* aliasesJson) {
-        NSDictionary *aliases = dictionaryFromJsonString(aliasesJson);
+    void _oneSignalUserAddAliases(const char* aliasesJson) {
+        NSDictionary *aliases = oneSignalDictionaryFromJsonString(aliasesJson);
 
         [OneSignal.User addAliases:aliases];
     }
 
-    void _userRemoveAlias(const char* aliasLabel) {
+    void _oneSignalUserRemoveAlias(const char* aliasLabel) {
         [OneSignal.User removeAlias:TO_NSSTRING(aliasLabel)];
     }
 
-    void _userRemoveAliases(const char* aliasesJson) {
-        NSArray *aliases = arrayFromJsonString(aliasesJson);
+    void _oneSignalUserRemoveAliases(const char* aliasesJson) {
+        NSArray *aliases = oneSignalArrayFromJsonString(aliasesJson);
 
         if (aliases == nil) {
             NSLog(@"[Onesignal] Could not parse aliases to delete");
@@ -114,39 +114,39 @@ extern "C" {
         [OneSignal.User removeAliases:aliases];
     }
 
-    void _userAddEmail(const char* email) {
+    void _oneSignalUserAddEmail(const char* email) {
         [OneSignal.User addEmail:TO_NSSTRING(email)];
     }
 
-    void _userRemoveEmail(const char* email) {
+    void _oneSignalUserRemoveEmail(const char* email) {
         [OneSignal.User removeEmail:TO_NSSTRING(email)];
     }
 
-    void _userAddSms(const char* smsNumber) {
+    void _oneSignalUserAddSms(const char* smsNumber) {
         [OneSignal.User addSms:TO_NSSTRING(smsNumber)];
     }
 
-    void _userRemoveSms(const char* smsNumber) {
+    void _oneSignalUserRemoveSms(const char* smsNumber) {
         [OneSignal.User removeSms:TO_NSSTRING(smsNumber)];
     }
 
-    void _userAddTag(const char* key, const char* value) {
+    void _oneSignalUserAddTag(const char* key, const char* value) {
         [OneSignal.User addTagWithKey:TO_NSSTRING(key)
                                 value:TO_NSSTRING(value)];
     }
 
-    void _userAddTags(const char* tagsJson) {
-        NSDictionary *tags = dictionaryFromJsonString(tagsJson);
+    void _oneSignalUserAddTags(const char* tagsJson) {
+        NSDictionary *tags = oneSignalDictionaryFromJsonString(tagsJson);
 
         [OneSignal.User addTags:tags];
     }
 
-    void _userRemoveTag(const char* key) {
+    void _oneSignalUserRemoveTag(const char* key) {
         [OneSignal.User removeTag:TO_NSSTRING(key)];
     }
 
-    void _userRemoveTags(const char* tagsJson) {
-        NSArray *tags = arrayFromJsonString(tagsJson);
+    void _oneSignalUserRemoveTags(const char* tagsJson) {
+        NSArray *tags = oneSignalArrayFromJsonString(tagsJson);
 
         if (tags == nil) {
             NSLog(@"[Onesignal] Could not parse tags to delete");
@@ -156,27 +156,27 @@ extern "C" {
         [OneSignal.User removeTags:tags];
     }
 
-    const char* _pushSubscriptionGetId() {
+    const char* _oneSignalPushSubscriptionGetId() {
         return strdup([OneSignal.User.pushSubscription.id UTF8String]);
     }
 
-    const char* _pushSubscriptionGetToken() {
+    const char* _oneSignalPushSubscriptionGetToken() {
         return strdup([OneSignal.User.pushSubscription.token UTF8String]);
     }
 
-    bool _pushSubscriptionGetOptedIn() {
+    bool _oneSignalPushSubscriptionGetOptedIn() {
         return OneSignal.User.pushSubscription.optedIn;
     }
 
-    void _pushSubscriptionOptIn() {
+    void _oneSignalPushSubscriptionOptIn() {
         [OneSignal.User.pushSubscription optIn];
     }
 
-    void _pushSubscriptionOptOut() {
+    void _oneSignalPushSubscriptionOptOut() {
         [OneSignal.User.pushSubscription optOut];
     }
 
-    void _pushSubscriptionAddStateChangedCallback(StateListenerDelegate callback) {
+    void _oneSignalPushSubscriptionAddStateChangedCallback(StateListenerDelegate callback) {
         [[OneSignalUserObserver sharedUserObserver] setPushSubscriptionDelegate:callback];
     }
 }

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/UIApplication+OneSignalUnity.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/UIApplication+OneSignalUnity.mm
@@ -31,12 +31,11 @@
 #import "UIApplication+OneSignalUnity.h"
 #import <objc/runtime.h>
 
-// from OneSignalSelectorHelpers.m
-static Class getClassWithProtocolInHierarchy(Class searchClass, Protocol *protocolToFind) {
+static Class oneSignalGetClassWithProtocolInHierarchy(Class searchClass, Protocol *protocolToFind) {
     if (!class_conformsToProtocol(searchClass, protocolToFind)) {
         if ([searchClass superclass] == [NSObject class])
             return nil;
-        Class foundClass = getClassWithProtocolInHierarchy([searchClass superclass], protocolToFind);
+        Class foundClass = oneSignalGetClassWithProtocolInHierarchy([searchClass superclass], protocolToFind);
         if (foundClass)
             return foundClass;
         return searchClass;
@@ -45,7 +44,7 @@ static Class getClassWithProtocolInHierarchy(Class searchClass, Protocol *protoc
 }
 
 // from OneSignalSelectorHelpers.m
-BOOL injectSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel) {
+BOOL oneSignalInjectSelector(Class newClass, SEL newSel, Class addToClass, SEL makeLikeSel) {
     Method newMeth = class_getInstanceMethod(newClass, newSel);
     IMP imp = method_getImplementation(newMeth);
 
@@ -82,9 +81,9 @@ static bool swizzled = false;
         return;
     }
 
-    Class delegateClass = getClassWithProtocolInHierarchy([delegate class], @protocol(UIApplicationDelegate));
+    Class delegateClass = oneSignalGetClassWithProtocolInHierarchy([delegate class], @protocol(UIApplicationDelegate));
 
-    injectSelector(
+    oneSignalInjectSelector(
         self.class, @selector(oneSignalApplication:didFinishLaunchingWithOptions:),
         delegateClass, @selector(application:didFinishLaunchingWithOptions:)
     );

--- a/com.onesignal.unity.ios/Runtime/iOSDebugManager.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSDebugManager.cs
@@ -32,8 +32,8 @@ using OneSignalSDK.Debug.Models;
 
 namespace OneSignalSDK.iOS.Debug {
     internal sealed class iOSDebugManager : IDebugManager {
-        [DllImport("__Internal")] private static extern void _debugSetLogLevel(int logLevel);
-        [DllImport("__Internal")] private static extern void _debugSetAlertLevel(int alertlLevel);
+        [DllImport("__Internal")] private static extern void _oneSignalDebugSetLogLevel(int logLevel);
+        [DllImport("__Internal")] private static extern void _oneSignalDebugSetAlertLevel(int alertlLevel);
 
         private LogLevel _logLevel = LogLevel.Warn;
         private LogLevel _alertLevel = LogLevel.None;
@@ -42,7 +42,7 @@ namespace OneSignalSDK.iOS.Debug {
             get => _logLevel;
             set {
                 _logLevel = value;
-                _debugSetLogLevel((int) value);
+                _oneSignalDebugSetLogLevel((int) value);
             }
         }
 
@@ -50,7 +50,7 @@ namespace OneSignalSDK.iOS.Debug {
             get => _alertLevel;
             set {
                 _alertLevel = value;
-                _debugSetAlertLevel((int) value);
+                _oneSignalDebugSetAlertLevel((int) value);
             }
         }
     }

--- a/com.onesignal.unity.ios/Runtime/iOSDisplayableNotification.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSDisplayableNotification.cs
@@ -33,9 +33,9 @@ using OneSignalSDK.Notifications.Models;
 
 namespace OneSignalSDK.iOS.Notifications.Models {
     public sealed class iOSDisplayableNotification : Notification, IDisplayableNotification {
-        [DllImport("__Internal")] private static extern void _notificationsDisplay(string notificationId);
+        [DllImport("__Internal")] private static extern void _oneSignalNotificationsDisplay(string notificationId);
 
         public void Display()
-            => _notificationsDisplay(this.NotificationId);
+            => _oneSignalNotificationsDisplay(this.NotificationId);
     }
 }

--- a/com.onesignal.unity.ios/Runtime/iOSInAppMessagesManager.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSInAppMessagesManager.cs
@@ -36,19 +36,19 @@ using OneSignalSDK.InAppMessages.Internal;
 
 namespace OneSignalSDK.iOS.InAppMessages {
     internal sealed class iOSInAppMessagesManager : IInAppMessagesManager {
-        [DllImport("__Internal")] private static extern void _inAppMessagesSetWillDisplayCallback(StringListenerDelegate callback);
-        [DllImport("__Internal")] private static extern void _inAppMessagesSetDidDisplayCallback(StringListenerDelegate callback);
-        [DllImport("__Internal")] private static extern void _inAppMessagesSetWillDismissCallback(StringListenerDelegate callback);
-        [DllImport("__Internal")] private static extern void _inAppMessagesSetDidDismissCallback(StringListenerDelegate callback);
-        [DllImport("__Internal")] private static extern void _inAppMessagesSetClickCallback(ClickListenerDelegate callback);
+        [DllImport("__Internal")] private static extern void _oneSignalInAppMessagesSetWillDisplayCallback(StringListenerDelegate callback);
+        [DllImport("__Internal")] private static extern void _oneSignalInAppMessagesSetDidDisplayCallback(StringListenerDelegate callback);
+        [DllImport("__Internal")] private static extern void _oneSignalInAppMessagesSetWillDismissCallback(StringListenerDelegate callback);
+        [DllImport("__Internal")] private static extern void _oneSignalInAppMessagesSetDidDismissCallback(StringListenerDelegate callback);
+        [DllImport("__Internal")] private static extern void _oneSignalInAppMessagesSetClickCallback(ClickListenerDelegate callback);
 
-        [DllImport("__Internal")] private static extern void _inAppMessagesSetPaused(bool paused);
-        [DllImport("__Internal")] private static extern bool _inAppMessagesGetPaused();
-        [DllImport("__Internal")] private static extern void _inAppMessagesAddTrigger(string key, string value);
-        [DllImport("__Internal")] private static extern void _inAppMessagesAddTriggers(string triggersJson);
-        [DllImport("__Internal")] private static extern void _inAppMessagesRemoveTrigger(string key);
-        [DllImport("__Internal")] private static extern void _inAppMessagesRemoveTriggers(string triggersJson);
-        [DllImport("__Internal")] private static extern void _inAppMessagesClearTriggers();
+        [DllImport("__Internal")] private static extern void _oneSignalInAppMessagesSetPaused(bool paused);
+        [DllImport("__Internal")] private static extern bool _oneSignalInAppMessagesGetPaused();
+        [DllImport("__Internal")] private static extern void _oneSignalInAppMessagesAddTrigger(string key, string value);
+        [DllImport("__Internal")] private static extern void _oneSignalInAppMessagesAddTriggers(string triggersJson);
+        [DllImport("__Internal")] private static extern void _oneSignalInAppMessagesRemoveTrigger(string key);
+        [DllImport("__Internal")] private static extern void _oneSignalInAppMessagesRemoveTriggers(string triggersJson);
+        [DllImport("__Internal")] private static extern void _oneSignalInAppMessagesClearTriggers();
 
         private delegate void StringListenerDelegate(string response);
         private delegate void ClickListenerDelegate(string message, string result, int urlType);
@@ -66,31 +66,31 @@ namespace OneSignalSDK.iOS.InAppMessages {
         }
 
         public bool Paused {
-            get => _inAppMessagesGetPaused();
-            set => _inAppMessagesSetPaused(value);
+            get => _oneSignalInAppMessagesGetPaused();
+            set => _oneSignalInAppMessagesSetPaused(value);
         }
 
         public void AddTrigger(string key, string value)
-            => _inAppMessagesAddTrigger(key, value.ToString());
+            => _oneSignalInAppMessagesAddTrigger(key, value.ToString());
 
         public void AddTriggers(Dictionary<string, string> triggers)
-            => _inAppMessagesAddTriggers(Json.Serialize(triggers));
+            => _oneSignalInAppMessagesAddTriggers(Json.Serialize(triggers));
 
         public void RemoveTrigger(string key)
-            => _inAppMessagesRemoveTrigger(key);
+            => _oneSignalInAppMessagesRemoveTrigger(key);
 
         public void RemoveTriggers(params string[] keys)
-            => _inAppMessagesRemoveTriggers(Json.Serialize(keys));
+            => _oneSignalInAppMessagesRemoveTriggers(Json.Serialize(keys));
 
         public void ClearTriggers()
-            => _inAppMessagesClearTriggers();
+            => _oneSignalInAppMessagesClearTriggers();
 
         public void Initialize() {
-            _inAppMessagesSetWillDisplayCallback(_onWillDisplay);
-            _inAppMessagesSetDidDisplayCallback(_onDidDisplay);
-            _inAppMessagesSetWillDismissCallback(_onWillDismiss);
-            _inAppMessagesSetDidDismissCallback(_onDidDismiss);
-            _inAppMessagesSetClickCallback(_onClicked);
+            _oneSignalInAppMessagesSetWillDisplayCallback(_onWillDisplay);
+            _oneSignalInAppMessagesSetDidDisplayCallback(_onDidDisplay);
+            _oneSignalInAppMessagesSetWillDismissCallback(_onWillDismiss);
+            _oneSignalInAppMessagesSetDidDismissCallback(_onDidDismiss);
+            _oneSignalInAppMessagesSetClickCallback(_onClicked);
         }
 
         [AOT.MonoPInvokeCallback(typeof(StringListenerDelegate))]

--- a/com.onesignal.unity.ios/Runtime/iOSLiveActivitiesManager.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSLiveActivitiesManager.cs
@@ -32,20 +32,20 @@ using OneSignalSDK.iOS.Utilities;
 
 namespace OneSignalSDK.iOS.LiveActivities {
     internal sealed class iOSLiveActivitiesManager : ILiveActivitiesManager {
-        [DllImport("__Internal")] private static extern void _enterLiveActivity(string activityId, string token, int hashCode, BooleanResponseDelegate callback);
-        [DllImport("__Internal")] private static extern void _exitLiveActivity(string activityId, int hashCode, BooleanResponseDelegate callback);
+        [DllImport("__Internal")] private static extern void _oneSignalEnterLiveActivity(string activityId, string token, int hashCode, BooleanResponseDelegate callback);
+        [DllImport("__Internal")] private static extern void _oneSignalExitLiveActivity(string activityId, int hashCode, BooleanResponseDelegate callback);
 
         private delegate void BooleanResponseDelegate(int hashCode, bool response);
 
         public async Task<bool> EnterAsync(string activityId, string token) {
             var (proxy, hashCode) = WaitingProxy._setupProxy<bool>();
-            _enterLiveActivity(activityId, token, hashCode, BooleanCallbackProxy);
+            _oneSignalEnterLiveActivity(activityId, token, hashCode, BooleanCallbackProxy);
             return await proxy;
         }
 
         public async Task<bool> ExitAsync(string activityId) {
             var (proxy, hashCode) = WaitingProxy._setupProxy<bool>();
-            _exitLiveActivity(activityId, hashCode, BooleanCallbackProxy);
+            _oneSignalExitLiveActivity(activityId, hashCode, BooleanCallbackProxy);
             return await proxy;
         }
 

--- a/com.onesignal.unity.ios/Runtime/iOSLocationManager.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSLocationManager.cs
@@ -32,17 +32,17 @@ using System.Runtime.InteropServices;
 
 namespace OneSignalSDK.iOS.Location {
     internal sealed class iOSLocationManager : ILocationManager {
-        [DllImport("__Internal")] private static extern bool _locationGetIsShared();
-        [DllImport("__Internal")] private static extern void _locationSetIsShared(bool shared);
-        [DllImport("__Internal")] private static extern void _locationRequestPermission();
+        [DllImport("__Internal")] private static extern bool _oneSignalLocationGetIsShared();
+        [DllImport("__Internal")] private static extern void _oneSignalLocationSetIsShared(bool shared);
+        [DllImport("__Internal")] private static extern void _oneSignalLocationRequestPermission();
 
         public bool IsShared {
-            get => _locationGetIsShared();
-            set => _locationSetIsShared(value);
+            get => _oneSignalLocationGetIsShared();
+            set => _oneSignalLocationSetIsShared(value);
         }
 
         public void RequestPermission() {
-            _locationRequestPermission();
+            _oneSignalLocationRequestPermission();
         }
     }
 }

--- a/com.onesignal.unity.ios/Runtime/iOSNotificationsManager.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSNotificationsManager.cs
@@ -38,15 +38,15 @@ using OneSignalSDK.iOS.Notifications.Models;
 
 namespace OneSignalSDK.iOS.Notifications {
     internal sealed class iOSNotificationsManager : INotificationsManager {
-        [DllImport("__Internal")] private static extern bool _notificationsGetPermission();
-        [DllImport("__Internal")] private static extern bool _notificationsGetCanRequestPermission();
-        [DllImport("__Internal")] private static extern int _notificationsGetPermissionNative();
-        [DllImport("__Internal")] private static extern void _notificationsRequestPermission(bool fallbackToSettings, int hashCode, BooleanResponseDelegate callback);
-        [DllImport("__Internal")] private static extern void _notificationsClearAll();
-        [DllImport("__Internal")] private static extern void _notificationsAddPermissionObserver(PermissionListenerDelegate callback);
-        [DllImport("__Internal")] private static extern void _notificationsSetForegroundWillDisplayCallback(WillDisplayListenerDelegate callback);
-        [DllImport("__Internal")] private static extern void _notificationsWillDisplayEventPreventDefault(string notificationId);
-        [DllImport("__Internal")] private static extern void _notificationsSetClickCallback(ClickListenerDelegate callback);
+        [DllImport("__Internal")] private static extern bool _oneSignalNotificationsGetPermission();
+        [DllImport("__Internal")] private static extern bool _oneSignalNotificationsGetCanRequestPermission();
+        [DllImport("__Internal")] private static extern int _oneSignalNotificationsGetPermissionNative();
+        [DllImport("__Internal")] private static extern void _oneSignalNotificationsRequestPermission(bool fallbackToSettings, int hashCode, BooleanResponseDelegate callback);
+        [DllImport("__Internal")] private static extern void _oneSignalNotificationsClearAll();
+        [DllImport("__Internal")] private static extern void _oneSignalNotificationsAddPermissionObserver(PermissionListenerDelegate callback);
+        [DllImport("__Internal")] private static extern void _oneSignalNotificationsSetForegroundWillDisplayCallback(WillDisplayListenerDelegate callback);
+        [DllImport("__Internal")] private static extern void _oneSignalNotificationsWillDisplayEventPreventDefault(string notificationId);
+        [DllImport("__Internal")] private static extern void _oneSignalNotificationsSetClickCallback(ClickListenerDelegate callback);
 
         private delegate void PermissionListenerDelegate(bool permission);
         private delegate void WillDisplayListenerDelegate(string notification);
@@ -66,7 +66,7 @@ namespace OneSignalSDK.iOS.Notifications {
 
                 if (!_clickNativeListenerSet) {
                     _clickNativeListenerSet = true;
-                    _notificationsSetClickCallback(_onClicked);
+                    _oneSignalNotificationsSetClickCallback(_onClicked);
                 }
             }
             remove { _clicked -= value; }
@@ -79,30 +79,30 @@ namespace OneSignalSDK.iOS.Notifications {
         }
 
         public bool Permission {
-            get => _notificationsGetPermission();
+            get => _oneSignalNotificationsGetPermission();
         }
 
         public bool CanRequestPermission {
-            get => _notificationsGetCanRequestPermission();
+            get => _oneSignalNotificationsGetCanRequestPermission();
         }
 
         public NotificationPermission PermissionNative {
-            get => (NotificationPermission)_notificationsGetPermissionNative();
+            get => (NotificationPermission)_oneSignalNotificationsGetPermissionNative();
         }
 
         public async Task<bool> RequestPermissionAsync(bool fallbackToSettings) {
             var (proxy, hashCode) = WaitingProxy._setupProxy<bool>();
-            _notificationsRequestPermission(fallbackToSettings, hashCode, BooleanCallbackProxy);
+            _oneSignalNotificationsRequestPermission(fallbackToSettings, hashCode, BooleanCallbackProxy);
             return await proxy;
         }
 
         public void ClearAllNotifications() {
-            _notificationsClearAll();
+            _oneSignalNotificationsClearAll();
         }
 
         public void Initialize() {
-            _notificationsAddPermissionObserver(_onPermissionStateChanged);
-            _notificationsSetForegroundWillDisplayCallback(_onForegroundWillDisplay);
+            _oneSignalNotificationsAddPermissionObserver(_onPermissionStateChanged);
+            _oneSignalNotificationsSetForegroundWillDisplayCallback(_onForegroundWillDisplay);
         }
 
         [AOT.MonoPInvokeCallback(typeof(PermissionListenerDelegate))]
@@ -137,7 +137,7 @@ namespace OneSignalSDK.iOS.Notifications {
             public InternalNotificationWillDisplayEventArgs(IDisplayableNotification notification) : base(notification) { }
 
             public override void PreventDefault() {
-                _notificationsWillDisplayEventPreventDefault(this.Notification.NotificationId);
+                _oneSignalNotificationsWillDisplayEventPreventDefault(this.Notification.NotificationId);
             }
         }
 

--- a/com.onesignal.unity.ios/Runtime/iOSPushSubscription.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSPushSubscription.cs
@@ -35,12 +35,12 @@ using OneSignalSDK.Debug.Utilities;
 
 namespace OneSignalSDK.iOS.User.Models {
     internal sealed class iOSPushSubscription : IPushSubscription {
-        [DllImport("__Internal")] private static extern string _pushSubscriptionGetId();
-        [DllImport("__Internal")] private static extern string _pushSubscriptionGetToken();
-        [DllImport("__Internal")] private static extern bool _pushSubscriptionGetOptedIn();
-        [DllImport("__Internal")] private static extern void _pushSubscriptionOptIn();
-        [DllImport("__Internal")] private static extern void _pushSubscriptionOptOut();
-        [DllImport("__Internal")] private static extern void _pushSubscriptionAddStateChangedCallback(StateListenerDelegate callback);
+        [DllImport("__Internal")] private static extern string _oneSignalPushSubscriptionGetId();
+        [DllImport("__Internal")] private static extern string _oneSignalPushSubscriptionGetToken();
+        [DllImport("__Internal")] private static extern bool _oneSignalPushSubscriptionGetOptedIn();
+        [DllImport("__Internal")] private static extern void _oneSignalPushSubscriptionOptIn();
+        [DllImport("__Internal")] private static extern void _oneSignalPushSubscriptionOptOut();
+        [DllImport("__Internal")] private static extern void _oneSignalPushSubscriptionAddStateChangedCallback(StateListenerDelegate callback);
 
         public delegate void StateListenerDelegate(string current, string previous);
 
@@ -53,25 +53,25 @@ namespace OneSignalSDK.iOS.User.Models {
         }
 
         public string Id {
-            get => _pushSubscriptionGetId();
+            get => _oneSignalPushSubscriptionGetId();
         }
 
         public string Token {
-            get => _pushSubscriptionGetToken();
+            get => _oneSignalPushSubscriptionGetToken();
         }
 
         public bool OptedIn {
-            get => _pushSubscriptionGetOptedIn();
+            get => _oneSignalPushSubscriptionGetOptedIn();
         }
 
         public void OptIn()
-            => _pushSubscriptionOptIn();
+            => _oneSignalPushSubscriptionOptIn();
 
         public void OptOut()
-            => _pushSubscriptionOptOut();
+            => _oneSignalPushSubscriptionOptOut();
 
         public void Initialize() {
-            _pushSubscriptionAddStateChangedCallback(_onPushSubscriptionStateChanged);
+            _oneSignalPushSubscriptionAddStateChangedCallback(_onPushSubscriptionStateChanged);
         }
 
         [AOT.MonoPInvokeCallback(typeof(StateListenerDelegate))]

--- a/com.onesignal.unity.ios/Runtime/iOSSessionManager.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSSessionManager.cs
@@ -31,17 +31,17 @@ using System.Runtime.InteropServices;
 
 namespace OneSignalSDK.iOS.Session {
     internal sealed class iOSSessionManager : ISessionManager {
-        [DllImport("__Internal")] private static extern void _sessionAddOutcome(string name);
-        [DllImport("__Internal")] private static extern void _sessionAddUniqueOutcome(string name);
-        [DllImport("__Internal")] private static extern void _sessionAddOutcomeWithValue(string name, float value);
+        [DllImport("__Internal")] private static extern void _oneSignalSessionAddOutcome(string name);
+        [DllImport("__Internal")] private static extern void _oneSignalSessionAddUniqueOutcome(string name);
+        [DllImport("__Internal")] private static extern void _oneSignalSessionAddOutcomeWithValue(string name, float value);
 
         public void AddOutcome(string name)
-            => _sessionAddOutcome(name);
+            => _oneSignalSessionAddOutcome(name);
 
         public void AddUniqueOutcome(string name)
-            => _sessionAddUniqueOutcome(name);
+            => _oneSignalSessionAddUniqueOutcome(name);
 
         public void AddOutcomeWithValue(string name, float value)
-            => _sessionAddOutcomeWithValue(name, value);
+            => _oneSignalSessionAddOutcomeWithValue(name, value);
     }
 }

--- a/com.onesignal.unity.ios/Runtime/iOSUserManager.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSUserManager.cs
@@ -35,19 +35,19 @@ using OneSignalSDK.iOS.User.Models;
 
 namespace OneSignalSDK.iOS.User {
     internal sealed class iOSUserManager : IUserManager {
-        [DllImport("__Internal")] private static extern void _userSetLanguage(string languageCode);
-        [DllImport("__Internal")] private static extern void _userAddAlias(string aliasLabel, string aliasId);
-        [DllImport("__Internal")] private static extern void _userAddAliases(string aliasesJson);
-        [DllImport("__Internal")] private static extern void _userRemoveAlias(string aliasLabel);
-        [DllImport("__Internal")] private static extern void _userRemoveAliases(string aliasesJson);
-        [DllImport("__Internal")] private static extern void _userAddEmail(string email);
-        [DllImport("__Internal")] private static extern void _userRemoveEmail(string email);
-        [DllImport("__Internal")] private static extern void _userAddSms(string smsNumber);
-        [DllImport("__Internal")] private static extern void _userRemoveSms(string smsNumber);
-        [DllImport("__Internal")] private static extern void _userAddTag(string key, string value);
-        [DllImport("__Internal")] private static extern void _userAddTags(string tagsJson);
-        [DllImport("__Internal")] private static extern void _userRemoveTag(string key);
-        [DllImport("__Internal")] private static extern void _userRemoveTags(string tagsJson);
+        [DllImport("__Internal")] private static extern void _oneSignalUserSetLanguage(string languageCode);
+        [DllImport("__Internal")] private static extern void _oneSignalUserAddAlias(string aliasLabel, string aliasId);
+        [DllImport("__Internal")] private static extern void _oneSignalUserAddAliases(string aliasesJson);
+        [DllImport("__Internal")] private static extern void _oneSignalUserRemoveAlias(string aliasLabel);
+        [DllImport("__Internal")] private static extern void _oneSignalUserRemoveAliases(string aliasesJson);
+        [DllImport("__Internal")] private static extern void _oneSignalUserAddEmail(string email);
+        [DllImport("__Internal")] private static extern void _oneSignalUserRemoveEmail(string email);
+        [DllImport("__Internal")] private static extern void _oneSignalUserAddSms(string smsNumber);
+        [DllImport("__Internal")] private static extern void _oneSignalUserRemoveSms(string smsNumber);
+        [DllImport("__Internal")] private static extern void _oneSignalUserAddTag(string key, string value);
+        [DllImport("__Internal")] private static extern void _oneSignalUserAddTags(string tagsJson);
+        [DllImport("__Internal")] private static extern void _oneSignalUserRemoveTag(string key);
+        [DllImport("__Internal")] private static extern void _oneSignalUserRemoveTags(string tagsJson);
 
         private iOSPushSubscription _pushSubscription;
         
@@ -60,44 +60,44 @@ namespace OneSignalSDK.iOS.User {
         }
 
         public string Language {
-            set => _userSetLanguage(value);
+            set => _oneSignalUserSetLanguage(value);
         }
 
         public void AddTag(string key, string value)
-            =>_userAddTag(key, value);
+            =>_oneSignalUserAddTag(key, value);
 
         public void AddTags(Dictionary<string, string> tags)
-            => _userAddTags(Json.Serialize(tags));
+            => _oneSignalUserAddTags(Json.Serialize(tags));
 
         public void RemoveTag(string key)
-            => _userRemoveTag(key);
+            => _oneSignalUserRemoveTag(key);
 
         public void RemoveTags(params string[] keys)
-            => _userRemoveTags(Json.Serialize(keys));
+            => _oneSignalUserRemoveTags(Json.Serialize(keys));
 
         public void AddAlias(string label, string id)
-            => _userAddAlias(label, id);
+            => _oneSignalUserAddAlias(label, id);
 
         public void AddAliases(Dictionary<string, string> aliases)
-            => _userAddAliases(Json.Serialize(aliases));
+            => _oneSignalUserAddAliases(Json.Serialize(aliases));
 
         public void RemoveAlias(string label)
-            => _userRemoveAlias(label);
+            => _oneSignalUserRemoveAlias(label);
 
         public void RemoveAliases(params string[] labels)
-            => _userRemoveAliases(Json.Serialize(labels));
+            => _oneSignalUserRemoveAliases(Json.Serialize(labels));
 
         public void AddEmail(string email)
-            => _userAddEmail(email);
+            => _oneSignalUserAddEmail(email);
 
         public void RemoveEmail(string email)
-            => _userRemoveEmail(email);
+            => _oneSignalUserRemoveEmail(email);
 
         public void AddSms(string sms)
-            => _userAddSms(sms);
+            => _oneSignalUserAddSms(sms);
 
         public void RemoveSms(string sms)
-            => _userRemoveSms(sms);
+            => _oneSignalUserRemoveSms(sms);
 
         public void Initialize() {
             _pushSubscription.Initialize();


### PR DESCRIPTION
# Description
## One Line Summary
Adds "OneSignal" prefix to Objective-C methods to avoid name conflicts with other iOS plugins

## Details

### Motivation
Fixes #663

# Testing
## Manual testing
Tested OneSignal initialization, app build with Unity 2022.3.10f1 of the OneSignal example app on a physical iPhone 12 with iOS 15.5.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/665)
<!-- Reviewable:end -->
