### PR TITLE
[Fix] OneSignalConfig.androidlib version numbers in build.gradle

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Duplicate symbol errors when building with other iOS plugins
+- Removed READ_PHONE_STATE permission in Android builds. Delete your OneSignalConfig.androidlib and run the 
+"Copy Android plugin to Assets" step in **Window > OneSignal SDK Setup** to apply the fix.
+- Fixed lower build-tools versions being needed for Android builds. Delete your OneSignalConfig.androidlib and run the 
+"Copy Android plugin to Assets" step in **Window > OneSignal SDK Setup** to apply the fix.
 ### Changed
 - Updated included Android SDK to [5.0.4](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.0.4)
 - Updated included iOS SDK to [5.0.4](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.0.4)

--- a/OneSignalExample/Assets/Plugins/Android/OneSignalConfig.androidlib/build.gradle
+++ b/OneSignalExample/Assets/Plugins/Android/OneSignalConfig.androidlib/build.gradle
@@ -7,11 +7,16 @@ android {
         }
     }
 
+    def unityLib = project(':unityLibrary').extensions.getByName('android')
+
    defaultConfig {
        consumerProguardFiles "consumer-proguard.pro"
+        minSdkVersion unityLib.defaultConfig.minSdk
+        targetSdkVersion unityLib.defaultConfig.targetSdk
    }
 
-    compileSdkVersion 31
+    compileSdkVersion unityLib.compileSdkVersion
+    buildToolsVersion unityLib.buildToolsVersion
 
     lintOptions {
         abortOnError false

--- a/OneSignalExample/Assets/Plugins/Android/OneSignalConfig.androidlib/build.gradle
+++ b/OneSignalExample/Assets/Plugins/Android/OneSignalConfig.androidlib/build.gradle
@@ -10,7 +10,7 @@ android {
     def unityLib = project(':unityLibrary').extensions.getByName('android')
 
    defaultConfig {
-       consumerProguardFiles "consumer-proguard.pro"
+        consumerProguardFiles "consumer-proguard.pro"
         minSdkVersion unityLib.defaultConfig.minSdk
         targetSdkVersion unityLib.defaultConfig.targetSdk
    }

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/build.gradle
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/build.gradle
@@ -7,11 +7,16 @@ android {
         }
     }
 
+    def unityLib = project(':unityLibrary').extensions.getByName('android')
+
    defaultConfig {
        consumerProguardFiles "consumer-proguard.pro"
+        minSdkVersion unityLib.defaultConfig.minSdk
+        targetSdkVersion unityLib.defaultConfig.targetSdk
    }
 
-    compileSdkVersion 31
+    compileSdkVersion unityLib.compileSdkVersion
+    buildToolsVersion unityLib.buildToolsVersion
 
     lintOptions {
         abortOnError false

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/build.gradle
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/build.gradle
@@ -10,7 +10,7 @@ android {
     def unityLib = project(':unityLibrary').extensions.getByName('android')
 
    defaultConfig {
-       consumerProguardFiles "consumer-proguard.pro"
+        consumerProguardFiles "consumer-proguard.pro"
         minSdkVersion unityLib.defaultConfig.minSdk
         targetSdkVersion unityLib.defaultConfig.targetSdk
    }


### PR DESCRIPTION
# Description
## One Line Summary
Sets version numbers in the OneSignalConfig.androidlib build.gradle to match the versions specified in Unity

## Details

### Motivation
Fixes https://github.com/OneSignal/OneSignal-Unity-SDK/issues/670 READ_PHONE_STATE permission being added to Android builds
Fixes lower build-tools versions being needed for Android builds than the [version the Unity Editor comes with](https://docs.unity3d.com/Manual/android-sdksetup.html)
- I was able to reproduce a licensing 30.0.3 build-tools build error in a new project with the OneSignal SDK on Unity 2022.3.14 which comes with build-tools 32.0.0. The lower build-tools error version may differ depending on the Unity Editor version.

Not specifying a version number in the build.gradle sets it to a low version instead. minSDKVersion was set to 1 and added the READ_PHONE_STATE permission. Lower build-tools versions than the one the Unity Editor comes with were being required when building for Android. compileSDKVersion and targetSDKVersion have also been changed to match the versions specified in Unity

### Scope
OneSignalConfig.androidlib has changed and devs need to regenerate it to apply the changes.
To apply the fix devs need to:
1. Delete their OneSignalConfig.androidlib
2. Go to **Window > OneSignal SDK Setup** and run the "Copy Android plugin to Assets" step

# Testing
## Manual testing
Tested OneSignal initialization, app build with Unity 2021.3.10f1 of the OneSignal example app on a emulated Pixel 4 with Android 12.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/673)
<!-- Reviewable:end -->
