### PR TITLE
[Fix] OneSignalConfig.androidlib minSdkVersion and targetSdkVersion for Unity 2021

### DIFF
--- a/OneSignalExample/Assets/Plugins/Android/OneSignalConfig.androidlib/build.gradle
+++ b/OneSignalExample/Assets/Plugins/Android/OneSignalConfig.androidlib/build.gradle
@@ -11,8 +11,8 @@ android {
 
    defaultConfig {
         consumerProguardFiles "consumer-proguard.pro"
-        minSdkVersion unityLib.defaultConfig.minSdk
-        targetSdkVersion unityLib.defaultConfig.targetSdk
+        minSdkVersion unityLib.defaultConfig.minSdkVersion.mApiLevel
+        targetSdkVersion unityLib.defaultConfig.targetSdkVersion.mApiLevel
    }
 
     compileSdkVersion unityLib.compileSdkVersion

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/build.gradle
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/build.gradle
@@ -11,8 +11,8 @@ android {
 
    defaultConfig {
         consumerProguardFiles "consumer-proguard.pro"
-        minSdkVersion unityLib.defaultConfig.minSdk
-        targetSdkVersion unityLib.defaultConfig.targetSdk
+        minSdkVersion unityLib.defaultConfig.minSdkVersion.mApiLevel
+        targetSdkVersion unityLib.defaultConfig.targetSdkVersion.mApiLevel
    }
 
     compileSdkVersion unityLib.compileSdkVersion


### PR DESCRIPTION
# Description
## One Line Summary
Fixes OneSignalConfig.androidlib minSdkVersion and targetSdkVersion Android build errors in Unity 2021

## Details

### Motivation
Fixes the following Android build error in Unity 2021.3.10 that occurs when calling `defaultConfig.minSdk` and similarly for `defaultConfig.targetSdk`. This error does not occur in Unity 2022.3.10.
```
A problem occurred evaluating project ':unityLibrary:OneSignalConfig.androidlib'.
> Could not get unknown property 'minSdk' for DefaultConfig_Decorated{name=main, dimension=null, minSdkVersion=DefaultApiVersion{mApiLevel=22, mCodename='null'}, targetSdkVersion=DefaultApiVersion{mApiLevel=30, mCodename='null'}, renderscriptTargetApi=null, renderscriptSupportModeEnabled=null, renderscriptSupportModeBlasEnabled=null, renderscriptNdkModeEnabled=null, versionCode=1, versionName=0.1, applicationId=null, testApplicationId=null, testInstrumentationRunner=null, testInstrumentationRunnerArguments={}, testHandleProfiling=null, testFunctionalTest=null, signingConfig=null, resConfig=[], mBuildConfigFields={}, mResValues={}, mProguardFiles=[], mConsumerProguardFiles=[/Users/shepherd/projects/My project (1)/Library/Bee/Android/Prj/Mono2x/Gradle/unityLibrary/proguard-unity.txt], mManifestPlaceholders={}, mWearAppUnbundled=null} of type com.android.build.gradle.internal.dsl.DefaultConfig.
```
 Both Unity versions successfully build when using `defaultConfig.minSdkVersion.mApiLevel` and `defaultConfig.minSdkVersion.mApiLevel`

### Scope
In the next release, devs need to apply the changes made to OneSignalConfig.androidlib:

1. Delete their current OneSignalConfig.androidlib in their Unity project
2. Go to Window > OneSignal SDK Setup and run the "Copy Android plugin to Assets" step to add the updated OneSignalConfig.androidlib back in their project

# Testing
## Manual testing
Tested building for Android on a new Unity project (3D Core template) with the OneSignal SDK installed with Unity 2021.3.10f1 and 2022.3.10f1. Also tested building for Android with the OneSignal example app on Unity 2022.3.10f1.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/675)
<!-- Reviewable:end -->
