### PR TITLE
[Feature] Update native OneSignal SDKs dependencies to 5.1.x

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed lower build-tools versions being needed for Android builds. Delete your OneSignalConfig.androidlib and run the 
 "Copy Android plugin to Assets" step in **Window > OneSignal SDK Setup** to apply the fix.
 ### Changed
-- Updated included Android SDK to [5.1.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.1)
+- Updated included Android SDK to [5.1.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.1).
+  - Android builds now require the Target API Level to be set to 33 or higher.
 - Updated included iOS SDK to [5.1.0](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.1.0)
 
 ## [5.0.5]

--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed lower build-tools versions being needed for Android builds. Delete your OneSignalConfig.androidlib and run the 
 "Copy Android plugin to Assets" step in **Window > OneSignal SDK Setup** to apply the fix.
 ### Changed
-- Updated included Android SDK to [5.0.4](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.0.4)
-- Updated included iOS SDK to [5.0.4](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.0.4)
+- Updated included Android SDK to [5.1.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.1)
+- Updated included iOS SDK to [5.1.0](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.1.0)
 
 ## [5.0.5]
 ### Changed

--- a/OneSignalExample/Assets/OneSignal/README.md
+++ b/OneSignalExample/Assets/OneSignal/README.md
@@ -33,6 +33,7 @@ And via many additional platforms. [Check them all out](https://documentation.on
 - A [OneSignal Account](https://app.onesignal.com/signup) if you do not already have one
 - Your OneSignal App ID which you can find under **Settings > Keys & IDs**
 - Unity 2021.3 or newer
+- Android Builds: Target API Level 33 or higher
 - iOS Builds: CocoaPods 1.11.3 or newer
 - In order to test push notifications you will need
   - An Android 4.0.3 or newer device or emulator with "Google Play services" installed

--- a/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
+++ b/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.library'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 // Android Resolver Dependencies Start
-    implementation 'com.onesignal:OneSignal:5.0.5' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
+    implementation 'com.onesignal:OneSignal:5.1.1' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
 // Android Resolver Dependencies End
 **DEPS**}
 

--- a/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
+++ b/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
   <packages>
-    <package>com.onesignal:OneSignal:5.0.5</package>
+    <package>com.onesignal:OneSignal:5.1.1</package>
   </packages>
   <files />
   <settings>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ And via many additional platforms. [Check them all out](https://documentation.on
 - A [OneSignal Account](https://app.onesignal.com/signup) if you do not already have one
 - Your OneSignal App ID which you can find under **Settings > Keys & IDs**
 - Unity 2021.3 or newer
+- Android Builds: Target API Level 33 or higher
 - iOS Builds: CocoaPods 1.11.3 or newer
 - In order to test push notifications you will need
   - An Android 5 or newer device or emulator with "Google Play Store (Services)" installed

--- a/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
+++ b/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
@@ -3,6 +3,6 @@
     <repositories>
       <repository>https://repo.maven.apache.org/maven2</repository>
     </repositories>
-    <androidPackage spec="com.onesignal:OneSignal:5.0.5" />
+    <androidPackage spec="com.onesignal:OneSignal:5.1.1" />
   </androidPackages>
 </dependencies>

--- a/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-            <iosPod name="OneSignalXCFramework" version="5.0.5" addToAllTargets="true" />
+            <iosPod name="OneSignalXCFramework" version="5.1.0" addToAllTargets="true" />
     </iosPods>
 </dependencies>


### PR DESCRIPTION
# Description
## One Line Summary
Updated included OneSignal Android SDK to [5.1.1](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.1) and OneSignal iOS SDK to [5.1.0](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.1.0)
## Details

### Motivation
Applies native fixes from the OneSignal Android SDK and OneSignal iOS SDK to the Unity SDK
- [OneSignal Android SDK 5.1.1 Release Notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.1)
  - Includes location behaviour change from [5.1.0](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.0):
     - You will need to include location permission in your own app's manifest
- [OneSignal iOS SDK 5.1.0 Release Notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.1.0)

### Scope
Unity developers must target API level 33 or higher to build for Android. This is because androidx.work:work-runtime-ktx:2.8.1 from the [OneSignal Android SDK](https://github.com/OneSignal/OneSignal-Android-SDK/pull/1960) requires compileSdkVersion 33 or higher.
Older versions of Unity do not include Android 33 by default - 2022 and below, so users will have to download it. Steps on how to do so are listed in the Unity docs: [Setting the Android SDK Target API](https://docs.unity3d.com/2023.3/Documentation/Manual/android-sdksetup.html).

# Testing
## Manual testing
Tested OneSignal initialization, app build with Unity 2022.3.10f1 of the OneSignal example app on a emulated Pixel 4 with Android 12 and physical iPhone 12 with iOS 15.5.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/689)
<!-- Reviewable:end -->
