### PR TITLE
[Fix] iOS Null PushSubscription Id and Token crash

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- iOS crash when calling OneSignal.User.PushSubscription.Id and OneSignal.User.PushSubscription.Token when they are null.
+
 ## [5.0.6]
 ### Fixed
 - Duplicate symbol errors when building with other iOS plugins

--- a/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeUser.mm
+++ b/com.onesignal.unity.ios/Runtime/Plugins/iOS/OneSignalUnityBridgeUser.mm
@@ -161,10 +161,16 @@ extern "C" {
     }
 
     const char* _oneSignalPushSubscriptionGetId() {
+        if (OneSignal.User.pushSubscription.id == NULL) {
+            return NULL;
+        }
         return strdup([OneSignal.User.pushSubscription.id UTF8String]);
     }
 
     const char* _oneSignalPushSubscriptionGetToken() {
+        if (OneSignal.User.pushSubscription.token == NULL) {
+            return NULL;
+        }
         return strdup([OneSignal.User.pushSubscription.token UTF8String]);
     }
 


### PR DESCRIPTION
# Description
## One Line Summary
Fixes crash on iOS when calling OneSignal.User.PushSubscription.Id or OneSignal.User.PushSubscription.Token when they are null.

## Details

### Motivation
Fixes iOS crash caused by calling `strdup` with a null parameter.

# Testing
## Manual testing
Tested by initializing OneSignal with no wifi connection and calling OneSignal.User.PushSubscription.Id and OneSignal.User.PushSubscription.Token, app build with Unity 2022.3.10f1 with a fresh install of the OneSignal example app on a physical iPhone 12 with iOS 15.5.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/697)
<!-- Reviewable:end -->
