### PR TITLE
[Fix] Request permission for notifications on Android when permission is true

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Resolves Android OneSignal.Notificaitons.RequestPermissionAsync() awaiting forever when notifications permission is true.
+
 ## [5.1.1]
 ### Changed
 - Updated included Android SDK to [5.1.6](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.6)

--- a/com.onesignal.unity.android/Runtime/AndroidNotificationsManager.cs
+++ b/com.onesignal.unity.android/Runtime/AndroidNotificationsManager.cs
@@ -60,6 +60,11 @@ namespace OneSignalSDK.Android.Notifications {
         }
 
         public async Task<bool> RequestPermissionAsync(bool fallbackToSettings) {
+            // if permission already exists, return early as the method call will not resolve
+            if (_notifications.Call<bool>("getPermission")) {
+                return true;
+            }
+
             var continuation = new BoolContinuation();
             _notifications.Call<AndroidJavaObject>("requestPermission", fallbackToSettings, continuation.Proxy);
             return await continuation;


### PR DESCRIPTION
# Description
## One Line Summary
Resolves notification request permission on Android when notification permission is true.

## Details

### Motivation
Calling OneSignal.Notificaitons.RequestPermissionAsync() on Android does not return when notification permission is true and awaits forever.

### Scope
Issue on wrappers that use Java bridge code. A check has to be added whereas on the native Android SDK, Kotlin resolves this automatically.

# Testing
## Manual testing
Tested OneSignal.Notificaitons.RequestPermissionAsync() returns true when notification permission is granted, app build with Unity 2021.3.10f1 of the OneSignal example App on a Pixel 6 with Android 13.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/716)
<!-- Reviewable:end -->
