### PR TITLE
[Feat] Update OneSignal Android and OneSignal iOS SDKs

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated included Android SDK from 5.1.10 to [5.1.13](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.13)
+  - Fixed the ANR issue caused by prolonged loading of OperationRepo and potentially by extended holding of the model lock during disk I/O read operations
+  - Fixed IndexOutOfBounds exception thrown from OperationRepo.loadSavedOperations if app was opened offline, some operations done, and then the app is opened again
+  - Targets JDK11 instead of JDK21 to address build errors encountered on certain development environments using JDK versions below 21
+  - Fixed grouping skipping opRepoPostCreateDelay, causing operations being applied out of order when multiple login operations are pending
+  - Fixed cancelling permission request dialog not firing continuation
+  - Fixed RecoverFromDroppedLoginBug not running in very rare cases
+  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)
+- Updated included iOS SDK from 5.1.6 to [5.2.0](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.0)
+  - Added additional 6 privacy manifests to the 6 sub-targets that are included in the primary targets clients import
+  - Updated User Defaults API reason to include app groups for appropriate modules
+  - Fixed rare scenario of dropping data when multiple logins are called
+  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases)
+
 ## [5.1.4]
 ### Changed
 - Updated included Android SDK from 5.1.9 to [5.1.10](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.10)

--- a/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
+++ b/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.library'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 // Android Resolver Dependencies Start
-    implementation 'com.onesignal:OneSignal:5.1.10' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
+    implementation 'com.onesignal:OneSignal:5.1.13' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
 // Android Resolver Dependencies End
 **DEPS**}
 

--- a/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
+++ b/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
   <packages>
-    <package>com.onesignal:OneSignal:5.1.10</package>
+    <package>com.onesignal:OneSignal:5.1.13</package>
   </packages>
   <files />
   <settings>

--- a/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
+++ b/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
@@ -3,6 +3,6 @@
     <repositories>
       <repository>https://repo.maven.apache.org/maven2</repository>
     </repositories>
-    <androidPackage spec="com.onesignal:OneSignal:5.1.10" />
+    <androidPackage spec="com.onesignal:OneSignal:5.1.13" />
   </androidPackages>
 </dependencies>

--- a/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-            <iosPod name="OneSignalXCFramework" version="5.1.6" addToAllTargets="true" />
+            <iosPod name="OneSignalXCFramework" version="5.2.0" addToAllTargets="true" />
     </iosPods>
 </dependencies>


### PR DESCRIPTION
# Description
## One Line Summary
Updates included OneSignal Android SDK from 5.1.10 to [5.1.13](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.13) and OneSignal iOS SDK from 5.1.6 to [5.2.0](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.0)

## Details

### Motivation
Apply fixes made in the native SDKs to the Unity wrapper SDK.

### Scope
Updated included OneSignal Android SDK from 5.1.10 to [5.1.13](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.13)
  - Fixed the ANR issue caused by prolonged loading of OperationRepo and potentially by extended holding of the model lock during disk I/O read operations
  - Fixed IndexOutOfBounds exception thrown from OperationRepo.loadSavedOperations if app was opened offline, some operations done, and then the app is opened again
  - Targets JDK11 instead of JDK21 to address build errors encountered on certain development environments using JDK versions below 21
  - Fixed grouping skipping opRepoPostCreateDelay, causing operations being applied out of order when multiple login operations are pending
  - Fixed cancelling permission request dialog not firing continuation
  - Fixed RecoverFromDroppedLoginBug not running in very rare cases
  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)
 
Updated included OneSignal iOS SDK from 5.1.6 to [5.2.0](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.0)
  - Added additional 6 privacy manifests to the 6 sub-targets that are included in the primary targets clients import
  - Updated User Defaults API reason to include app groups for appropriate modules
  - Fixed rare scenario of dropping data when multiple logins are called
  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases)

Note: The OneSignal Unity SDK does not include Push to Start Live Activities in this update

# Testing
## Manual testing
Tested OneSignal initialization, app build with Unity 2022.3.10f1 of the OneSignal example app on a emulated Pixel 4 with Android 12.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/730)
<!-- Reviewable:end -->
