### PR TITLE
[Feat] Bump OneSignal Android and iOS SDK versions

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated included Android SDK from 5.1.13 to [5.1.17](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.17)
+  - Fixed Xiaomi notification click not foregrounding app
+  - Fixed FCM push token not being refreshed
+  - Poll for notification permission changes to detect permission change when prompting outside of OneSignal
+  - Cold start creates new session and refreshes the user from the server
+  - Immediately process pending operations when privacy consent goes from false to true
+  - Fixed OneSignal.Notifications.RequestPermissionAsync() not firing when permission was already granted
+  - Fixed Operation Model Store adding duplicate operations when the same ones that were previously added to the store and persisted, are re-read from cache
+  - Fixed a bug causing clicking an unexpanded group notification results in only registering the click result for the final notification in the group
+  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)
+- Updated included iOS SDK from 5.2.0 to [5.2.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.2)
+  - Prevent In-App Message request crashes by making null values safe
+  - Added Dispatch Queues to all executors to prevent concurrency crashes
+  - Fixed clearing notifications incorrectly such as when pulling down the notification center
+  - Fixed a purchases bug for the amount spent
+  - Fixed a build issue for mac catalyst
+  - Fixed crash when IAM window fails to load by using the main thread
+  - Network call optimizations: Combine user property updates for network call improvements
+  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases)
 ### Fixed
 - Additional instance of OneSignal error when calling OneSignal methods in Awake()
 - iOS Mac Catalyst build error: Use of undeclared identifier 'OneSignalLiveActivitiesManagerImpl'

--- a/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
+++ b/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.library'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 // Android Resolver Dependencies Start
-    implementation 'com.onesignal:OneSignal:5.1.13' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
+    implementation 'com.onesignal:OneSignal:5.1.17' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
 // Android Resolver Dependencies End
 **DEPS**}
 

--- a/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
+++ b/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
   <packages>
-    <package>com.onesignal:OneSignal:5.1.13</package>
+    <package>com.onesignal:OneSignal:5.1.17</package>
   </packages>
   <files />
   <settings>

--- a/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
+++ b/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
@@ -3,6 +3,6 @@
     <repositories>
       <repository>https://repo.maven.apache.org/maven2</repository>
     </repositories>
-    <androidPackage spec="com.onesignal:OneSignal:5.1.13" />
+    <androidPackage spec="com.onesignal:OneSignal:5.1.17" />
   </androidPackages>
 </dependencies>

--- a/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-            <iosPod name="OneSignalXCFramework" version="5.2.1" addToAllTargets="true" />
+            <iosPod name="OneSignalXCFramework" version="5.2.2" addToAllTargets="true" />
     </iosPods>
 </dependencies>


### PR DESCRIPTION
# Description
## One Line Summary
Updates included OneSignal Android SDK from 5.1.13 to [5.1.17](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.17) and OneSignal iOS SDK from 5.2.0 to [5.2.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.2)

## Details

### Motivation
Applies fixes made in the native SDKs to the Unity wrapper SDK.

### Scope
Updates included Android SDK from 5.1.13 to [5.1.17](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.17)
  - Fixes Xiaomi notification click not foregrounding app
  - Fixes FCM push token not being refreshed
  - Poll for notification permission changes to detect permission change when prompting outside of OneSignal
  - Cold start creates new session and refreshes the user from the server
  - Immediately process pending operations when privacy consent goes from false to true
  - Fixes OneSignal.Notifications.RequestPermissionAsync() not firing when permission was already granted
  - Fixes Operation Model Store adding duplicate operations when the same ones that were previously added to the store and persisted, are re-read from cache
  - Fixes a bug causing clicking an unexpanded group notification results in only registering the click result for the final notification in the group
  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)

Updates included iOS SDK from 5.2.0 to [5.2.2](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.2)
  - Prevent In-App Message request crashes by making null values safe
  - Added Dispatch Queues to all executors to prevent concurrency crashes
  - Fixes clearing notifications incorrectly such as when pulling down the notification center
  - Fixes a purchases bug for the amount spent
  - Fixes a build issue for mac catalyst
  - Fixes crash when IAM window fails to load by using the main thread
  - Network call optimizations: Combine user property updates for network call improvements
  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases)

# Testing
## Manual testing
Tested OneSignal initialization, app build with Unity 2022.3.10f1 of the OneSignal example app on a emulated Pixel 4 with Android 12 and a physical iPhone 12 with iOS 17.5.1.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/743)
<!-- Reviewable:end -->
