### PR TITLE
Bump OneSignal Android and iOS SDKs

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated included Android SDK from 5.1.17 to [5.1.20](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.20)
+  - Optimized the initialization process by moving some service initialization to a background thread
+  - Recover null onesignal ID crashes for Operations
+  - Add option to default to HMS over FCM
+  - Prevent retrying IAM display if 410 is received from backend
+  - Fix dynamic triggers showing IAM repeatedly after being dismissed
+  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)
+- Updated included iOS SDK from 5.2.2 to [5.2.3](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.3)
+  - The user executor needs to uncache first which fixes some cached requests being dropped for past users
+  - Omit misleading fatal-level log for cross-platform SDKs
+  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases)
+
 ## [5.1.7]
 ### Changed
 - Updated SDK to support Live Activities PushToStart and added a concept of a "Default" Live Activity to facilitate easier adoption. Please check out https://documentation.onesignal.com/docs/push-to-start-live-activities for more information and our [example app](https://github.com/OneSignal/OneSignal-Unity-SDK/tree/main/OneSignalExample) for an example implementation.

--- a/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
+++ b/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.library'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 // Android Resolver Dependencies Start
-    implementation 'com.onesignal:OneSignal:5.1.17' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
+    implementation 'com.onesignal:OneSignal:5.1.20' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
 // Android Resolver Dependencies End
 **DEPS**}
 

--- a/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
+++ b/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
   <packages>
-    <package>com.onesignal:OneSignal:5.1.17</package>
+    <package>com.onesignal:OneSignal:5.1.20</package>
   </packages>
   <files />
   <settings>

--- a/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
+++ b/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
@@ -3,6 +3,6 @@
     <repositories>
       <repository>https://repo.maven.apache.org/maven2</repository>
     </repositories>
-    <androidPackage spec="com.onesignal:OneSignal:5.1.17" />
+    <androidPackage spec="com.onesignal:OneSignal:5.1.20" />
   </androidPackages>
 </dependencies>

--- a/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-            <iosPod name="OneSignalXCFramework" version="5.2.2" addToAllTargets="true" />
+            <iosPod name="OneSignalXCFramework" version="5.2.3" addToAllTargets="true" />
     </iosPods>
 </dependencies>


### PR DESCRIPTION
# Description
## One Line Summary
Updates included OneSignal Android SDK from 5.1.17 to [5.1.20](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.20) and OneSignal iOS SDK from 5.2.2 to [5.2.3](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.3)

## Details

### Motivation
Applies fixes made in the native SDKs to the Unity wrapper SDK.

### Scope
- Updated included Android SDK from 5.1.17 to [5.1.20](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.20)
  - Optimized the initialization process by moving some service initialization to a background thread
  - Recover null onesignal ID crashes for Operations
  - Add option to default to HMS over FCM
  - Prevent retrying IAM display if 410 is received from backend
  - Fix dynamic triggers showing IAM repeatedly after being dismissed
  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)
- Updated included iOS SDK from 5.2.2 to [5.2.3](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.3)
  - The user executor needs to uncache first which fixes some cached requests being dropped for past users
  - Omit misleading fatal-level log for cross-platform SDKs
  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases)

# Testing
## Manual testing
Tested OneSignal initialization, app build with Unity 2022.3.10f1 of the OneSignal example app on a emulated Pixel 4 with Android 12 and a physical iPhone 12 with iOS 17.5.1.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/753)
<!-- Reviewable:end -->
