### PR TITLE
Fix Unity 6 Android compatibility with gradle

### DIFF
--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/build.gradle
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.onesignal.onesignalsdk'
+
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'


### PR DESCRIPTION


Confirmed this change works with Unity 6.0.42f1 and is still compatible with the Unity's oldest LTS, 2021.3.45f1.

# Description
## One Line Summary
Fixes Android build issue with Unity 6 as it's Gradle version requires `namespace` to be defined in the build.gradle.

## Details
This addresses Issues:
* https://github.com/OneSignal/OneSignal-Unity-SDK/issues/752
* https://github.com/OneSignal/OneSignal-Unity-SDK/issues/775

### Motivation
SDK should continue to be compatible with newer versions of Unity, without work arounds.

### Scope
Only effects the Android build process that runs on app developers projects.

# Testing
## Unit testing
No testing suite that builds an app end-to-end in place.

## Manual testing
Testing a new Unity project and ensure an Android APK was built successfully on:
* Unity 6.0.42f1
* Unity 2021.3.45f1 (Unity's oldest LTS)

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes
   - [ ] Android build system

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/776)
<!-- Reviewable:end -->
