### PR TITLE
Unity6; Automatically Android migration

### DIFF
--- a/OneSignalExample/Assets/Plugins/Android/OneSignalConfig.androidlib/build.gradle
+++ b/OneSignalExample/Assets/Plugins/Android/OneSignalConfig.androidlib/build.gradle
@@ -1,6 +1,12 @@
+/*
+   WARNING: Do NOT Modify! Changes will be overwritten by the OneSignal plugin.
+*/
+
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.onesignal.onesignalsdk'
+
     sourceSets {
         main {
             manifest.srcFile 'AndroidManifest.xml'
@@ -9,11 +15,11 @@ android {
 
     def unityLib = project(':unityLibrary').extensions.getByName('android')
 
-   defaultConfig {
+    defaultConfig {
         consumerProguardFiles "consumer-proguard.pro"
         minSdkVersion unityLib.defaultConfig.minSdkVersion.mApiLevel
         targetSdkVersion unityLib.defaultConfig.targetSdkVersion.mApiLevel
-   }
+    }
 
     compileSdkVersion unityLib.compileSdkVersion
     buildToolsVersion unityLib.buildToolsVersion

--- a/com.onesignal.unity.android/Editor/Migration/MigrateAndroidResources.cs
+++ b/com.onesignal.unity.android/Editor/Migration/MigrateAndroidResources.cs
@@ -1,0 +1,41 @@
+using System.IO;
+using UnityEditor;
+
+namespace OneSignalSDK {
+
+    [InitializeOnLoad]
+    sealed class MigrateAndroidResources {
+        static MigrateAndroidResources() {
+            UpdateBuildDotGradleContains();
+        }
+
+        /// <summary>
+        /// Updates Assets/Plugins/Android/OneSignalConfig.androidlib/build.gradle
+        /// with contains provided by OneSignal-Unity-SDK 5.1.13.
+        /// Includes compatibility with Unity 6, as it's Gradle version has new
+        /// requirements.
+        /// </summary>
+        private static void UpdateBuildDotGradleContains() {
+            if (!Directory.Exists(ExportAndroidResourcesStep._pluginExportPath))
+                return;
+
+            string exportedFilename = Path.Combine(
+                ExportAndroidResourcesStep._pluginExportPath,
+                "build.gradle"
+            );
+            string exportedContains = File.ReadAllText(exportedFilename);
+
+            string packageFilename = Path.Combine(
+                ExportAndroidResourcesStep._pluginPackagePath,
+                "build.gradle"
+            );
+            string packageContains = File.ReadAllText(packageFilename);
+
+            // We want to copy only when needed, otherwise it can reset file
+            // properties, such as permissions and timestamps
+            if (exportedContains != packageContains) {
+                File.Copy(packageFilename, exportedFilename, true);
+            }
+        }
+    }
+}

--- a/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/build.gradle
+++ b/com.onesignal.unity.android/Editor/OneSignalConfig.androidlib/build.gradle
@@ -1,3 +1,7 @@
+/*
+   WARNING: Do NOT Modify! Changes will be overwritten by the OneSignal plugin.
+*/
+
 apply plugin: 'com.android.library'
 
 android {
@@ -11,11 +15,11 @@ android {
 
     def unityLib = project(':unityLibrary').extensions.getByName('android')
 
-   defaultConfig {
+    defaultConfig {
         consumerProguardFiles "consumer-proguard.pro"
         minSdkVersion unityLib.defaultConfig.minSdkVersion.mApiLevel
         targetSdkVersion unityLib.defaultConfig.targetSdkVersion.mApiLevel
-   }
+    }
 
     compileSdkVersion unityLib.compileSdkVersion
     buildToolsVersion unityLib.buildToolsVersion

--- a/com.onesignal.unity.android/Editor/SetupSteps/ExportAndroidResourcesStep.cs
+++ b/com.onesignal.unity.android/Editor/SetupSteps/ExportAndroidResourcesStep.cs
@@ -131,8 +131,8 @@ namespace OneSignalSDK {
         private static readonly string _packagePath = Path.Combine("Packages", "com.onesignal.unity.android", "Editor");
         private static readonly string _androidPluginsPath = Path.Combine("Assets", "Plugins", "Android");
         
-        private static readonly string _pluginPackagePath = Path.Combine(_packagePath, _pluginName);
-        private static readonly string _pluginExportPath = Path.Combine(_androidPluginsPath, _pluginName);
+        internal static readonly string _pluginPackagePath = Path.Combine(_packagePath, _pluginName);
+        internal static readonly string _pluginExportPath = Path.Combine(_androidPluginsPath, _pluginName);
         
         private static readonly string _manifestPackagePath = Path.Combine(_pluginPackagePath, "AndroidManifest.xml");
         private static readonly string _manifestExportPath = Path.Combine(_pluginExportPath, "AndroidManifest.xml");


### PR DESCRIPTION
# Description
## One Line Summary
Automatically apply required changes for Unity 6 build compatibility, this only effects Android.

## Details
Follow up to PR https://github.com/OneSignal/OneSignal-Unity-SDK/pull/776

### Motivation
If changes were not applied automatic it will lead extra work the app developer has to search for or may reach out to OneSignal support for help.

### Scope
Only effects Android builds.

# Testing
## Unit testing
None

## Manual testing
Tested with Unity 6000.0.42f1.7976.8784 on macOS.
Made changes to the file located at `Assets/Plugins/Android/OneSignalConfig.androidlib/build.gradle` and ensured it reverts it.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/778)
<!-- Reviewable:end -->
