### PR TITLE
Bump native OneSignal SDKs; OneSignal-Android-SDK 5.1.31, OneSignal-iOS-SDK 5.2.10

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated included Android SDK from 5.1.26 to [5.1.31](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.31)
+  - [Fix] Incorrect activity path for NotificationOpenedActivityHMS
+  - [Fix] Anonymous Login request not cleared if app is forced close within 5 seconds on a new install
+  - [Fix] V4 to v5 upgrade will migrate app ID
+  - [Fix] Notification click not foreground the app in the first click if app is closed and no clickListener is added
+  - [Fix] Subscription/IAM not updated after upgrading from 5.2.0-beta or between 5.1.9 to 5.1.27
+  - [Fix] ANR caused by model.add(), model.initializeFromJson(), or modelstore.load()
+  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)
+- Updated included iOS SDK from 5.2.9 to [5.2.10](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.10)
+  - [Fix] Requiring privacy consent blocks confirmed deliveries indefinitely
+  - [Fix] Detect for timezone changes and update the user
+  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases)
 ## [5.1.12]
 ### Changed
 - Updated included Android SDK from 5.1.25 to [5.1.26](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.26)

--- a/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
+++ b/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.library'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 // Android Resolver Dependencies Start
-    implementation 'com.onesignal:OneSignal:5.1.26' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
+    implementation 'com.onesignal:OneSignal:5.1.31' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
 // Android Resolver Dependencies End
 **DEPS**}
 

--- a/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
+++ b/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
   <packages>
-    <package>com.onesignal:OneSignal:5.1.26</package>
+    <package>com.onesignal:OneSignal:5.1.31</package>
   </packages>
   <files />
   <settings>

--- a/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
+++ b/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
@@ -3,6 +3,6 @@
     <repositories>
       <repository>https://repo.maven.apache.org/maven2</repository>
     </repositories>
-    <androidPackage spec="com.onesignal:OneSignal:5.1.26" />
+    <androidPackage spec="com.onesignal:OneSignal:5.1.31" />
   </androidPackages>
 </dependencies>

--- a/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-            <iosPod name="OneSignalXCFramework" version="5.2.9" addToAllTargets="true" />
+            <iosPod name="OneSignalXCFramework" version="5.2.10" addToAllTargets="true" />
     </iosPods>
 </dependencies>


### PR DESCRIPTION
# Description
## One Line Summary
Update OneSignal native SDK to the latest versions.

## Details

### Motivation
Applies fixes from the OneSignal Android SDK and OneSignal iOS SDK to the Unity SDK.

### Scope
Updates both Android and iOS libraries to the latest versions.

# Testing
## Unit testing
None

## Manual testing
Just bumping versions, no testing.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/779)
<!-- Reviewable:end -->
