### PR TITLE
Add missing .meta android migration files

### DIFF
--- a/com.onesignal.unity.android/Editor/Migration.meta
+++ b/com.onesignal.unity.android/Editor/Migration.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b9f0ba3ec32a741249a1e188ca4b1b85
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.onesignal.unity.android/Editor/Migration/MigrateAndroidResources.cs.meta
+++ b/com.onesignal.unity.android/Editor/Migration/MigrateAndroidResources.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2259b76978bd4ae2a2a3ce0fef5347e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Description
## One Line Summary
Add missing .meta android migration files that were missed in PR #778.

## Details

### Motivation
Resolve error #781 when this SDK is load in the Unity editor.

### Scope
Only effects the Unity editor loading for Android.

# Testing
## Unit testing
None

## Manual testing

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Unity-SDK/782)
<!-- Reviewable:end -->
