### PR TITLE
Bump OneSignal native SDK versions

### DIFF
--- a/OneSignalExample/Assets/OneSignal/CHANGELOG.md
+++ b/OneSignalExample/Assets/OneSignal/CHANGELOG.md
@@ -5,6 +5,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [5.1.15]
+### Changed
+- Updated included Android SDK from 5.1.31 to [5.1.37](https://github.com/OneSignal/OneSignal-Android-SDK/releases/tag/5.1.37)
+  - [Fix] IAM not shown when calling login immediately after init
+  - [Fix] IAM now showing after switching to 3-button-navigation mode
+  - [Fix] very rare bug where app doesn't opening from notification tap when it cold starts the app
+  - [Fix] NPE when accessing WindowInsets used in isKeyboardUp()
+  - [Fix] NotificationOpenedActivity "freeze" when a large amount of notification is clicked
+  - [Fix] Crash when adding alias with some labels
+  - [Fix] Crashes with Amazon IAP tracking by dropping support for this
+  - [Fix] Push subscription observers not firing
+  - [Fix] Handle in-app messages dismissed by back press
+  - [Fix] Android 7 and lower crashes with getParameterCount calls
+  - [Fix] Logout incorrectly uses the old subscription ID
+  - [Fix] NPE in PermissionsActivity
+  - [Fix] Fix parsing subscriptions from server, and improve handling of deleted push subscriptions
+  - [Fix] Multiple create subscription operations exist without token
+  - [Fix] Finishing the activity on main thread when a notification is opened
+  - [Feature] Adds the following new public methods (#2311):
+    - OneSignal.Debug.addLogListener
+    - OneSignal.Debug.removeLogListener
+  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-Android-SDK/releases)
+- Updated included iOS SDK from 5.2.10 to [5.2.14](https://github.com/OneSignal/OneSignal-iOS-SDK/releases/tag/5.2.14)
+  - [Fix] Synchronize to fix crashes in the user module 
+  - [Fix] Prevent deadlocks when user manager runs its startup tasks
+  - [Fix] Bug when notification has badge set to zero
+  - [Fix] drop deprecated applicationIconBadgeNumber usage
+  - [Improvement] Ensure push tokens are registered for existing Live Activities during setup
+  - For full changes, see the [native release notes](https://github.com/OneSignal/OneSignal-iOS-SDK/releases)
 ## [5.1.14]
 ### Changed
 - [Fix] Missing .meta Android Migration files Unity editor error

--- a/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
+++ b/OneSignalExample/Assets/Plugins/Android/mainTemplate.gradle
@@ -6,7 +6,7 @@ apply plugin: 'com.android.library'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 // Android Resolver Dependencies Start
-    implementation 'com.onesignal:OneSignal:5.1.31' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
+    implementation 'com.onesignal:OneSignal:5.1.37' // Packages/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml:6
 // Android Resolver Dependencies End
 **DEPS**}
 

--- a/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
+++ b/OneSignalExample/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
   <packages>
-    <package>com.onesignal:OneSignal:5.1.31</package>
+    <package>com.onesignal:OneSignal:5.1.37</package>
   </packages>
   <files />
   <settings>

--- a/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
+++ b/com.onesignal.unity.android/Editor/OneSignalAndroidDependencies.xml
@@ -3,6 +3,6 @@
     <repositories>
       <repository>https://repo.maven.apache.org/maven2</repository>
     </repositories>
-    <androidPackage spec="com.onesignal:OneSignal:5.1.31" />
+    <androidPackage spec="com.onesignal:OneSignal:5.1.37" />
   </androidPackages>
 </dependencies>

--- a/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
+++ b/com.onesignal.unity.ios/Editor/OneSignaliOSDependencies.xml
@@ -1,5 +1,5 @@
 ﻿<dependencies>
     <iosPods>
-            <iosPod name="OneSignalXCFramework" version="5.2.10" addToAllTargets="true" />
+            <iosPod name="OneSignalXCFramework" version="5.2.14" addToAllTargets="true" />
     </iosPods>
 </dependencies>


### PR DESCRIPTION
# Description
## One Line Summary
Update OneSignal native SDK to the latest versions.

## Details

### Motivation
Applies fixes from the OneSignal Android SDK and OneSignal iOS SDK to the Unity SDK.

### Scope
Updates both Android and iOS libraries to the latest versions.

# Testing
## Unit testing
None

## Manual testing
Just bumping versions, no testing.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [X] I have included test coverage for these changes, or explained why they are not needed
   - [X] All automated tests pass, or I explained why that is not possible
   - [X] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [X] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [X] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.