### PR TITLE
fix: [SDK-4523] Unity custom event nested property encoding

### DIFF
--- a/com.onesignal.unity.android/Runtime/Utilities/AndroidJavaObjectExtensions.cs
+++ b/com.onesignal.unity.android/Runtime/Utilities/AndroidJavaObjectExtensions.cs
@@ -173,7 +173,9 @@ namespace OneSignalSDK.Android.Utilities
                         case bool boolValue:
                             value = new AndroidJavaObject("java.lang.Boolean", boolValue);
                             break;
-                        case Dictionary<string, object> dictValue:
+                        // Check IDictionary before IList: some dict-like types
+                        // (e.g. Newtonsoft's JObject) also implement IList.
+                        case System.Collections.IDictionary dictValue:
                             value = new AndroidJavaObject(
                                 "org.json.JSONObject",
                                 Json.Serialize(dictValue)

--- a/com.onesignal.unity.core/Runtime/Utilities/MiniJSON.cs
+++ b/com.onesignal.unity.core/Runtime/Utilities/MiniJSON.cs
@@ -509,13 +509,15 @@ namespace OneSignalSDK
                 {
                     builder.Append((bool)value ? "true" : "false");
                 }
-                else if ((asList = value as IList) != null)
-                {
-                    SerializeArray(asList);
-                }
+                // Check IDictionary before IList: some dict-like types (e.g. Newtonsoft's
+                // JObject) also implement IList, and would otherwise be serialized as arrays.
                 else if ((asDict = value as IDictionary) != null)
                 {
                     SerializeObject(asDict);
+                }
+                else if ((asList = value as IList) != null)
+                {
+                    SerializeArray(asList);
                 }
                 else if (value is char)
                 {

--- a/examples/demo/Assets/Scripts/UI/Dialogs/TrackEventDialog.cs
+++ b/examples/demo/Assets/Scripts/UI/Dialogs/TrackEventDialog.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using OneSignalSDK;
 using UnityEngine.UIElements;
 
 namespace OneSignalDemo.UI.Dialogs
@@ -75,14 +75,7 @@ namespace OneSignalDemo.UI.Dialogs
             var propsText = _propertiesField?.value;
             if (!string.IsNullOrEmpty(propsText))
             {
-                try
-                {
-                    JsonConvert.DeserializeObject<Dictionary<string, object>>(propsText);
-                }
-                catch
-                {
-                    _jsonValid = false;
-                }
+                _jsonValid = TryParseProperties(propsText, out _);
             }
 
             _jsonError.style.display = _jsonValid ? DisplayStyle.None : DisplayStyle.Flex;
@@ -97,20 +90,30 @@ namespace OneSignalDemo.UI.Dialogs
 
             Dictionary<string, object> props = null;
             var propsText = _propertiesField?.value;
-            if (!string.IsNullOrEmpty(propsText))
+            if (!string.IsNullOrEmpty(propsText) && !TryParseProperties(propsText, out props))
             {
-                try
-                {
-                    props = JsonConvert.DeserializeObject<Dictionary<string, object>>(propsText);
-                }
-                catch
-                {
-                    return;
-                }
+                return;
             }
 
             _onConfirm?.Invoke(name, props);
             Dismiss();
+        }
+
+        // Use the SDK's MiniJSON parser so nested objects/arrays come back as plain
+        // Dictionary<string, object> / List<object>. Newtonsoft would hand back
+        // JObject/JArray, which the native bridges then mis-serialize.
+        private static bool TryParseProperties(string propsText, out Dictionary<string, object> props)
+        {
+            props = null;
+            try
+            {
+                props = Json.Deserialize(propsText) as Dictionary<string, object>;
+            }
+            catch
+            {
+                return false;
+            }
+            return props != null;
         }
     }
 }

--- a/examples/demo/run-android.sh
+++ b/examples/demo/run-android.sh
@@ -6,8 +6,39 @@
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-UNITY="${UNITY_PATH:-/Applications/Unity/Hub/Editor/6000.3.6f1/Unity.app/Contents/MacOS/Unity}"
-ADB="/Applications/Unity/Hub/Editor/6000.3.6f1/PlaybackEngines/AndroidPlayer/SDK/platform-tools/adb"
+
+# Auto-detect newest Unity 6000.x install under the Hub, unless UNITY_PATH is set.
+find_unity() {
+  if [ -n "${UNITY_PATH:-}" ]; then
+    echo "$UNITY_PATH"
+    return
+  fi
+  for d in $(ls -1 /Applications/Unity/Hub/Editor 2>/dev/null | sort -rV); do
+    BIN="/Applications/Unity/Hub/Editor/$d/Unity.app/Contents/MacOS/Unity"
+    [ -x "$BIN" ] && echo "$BIN" && return
+  done
+}
+UNITY="$(find_unity)"
+
+# Resolve adb in this order: $ADB, $ANDROID_HOME/platform-tools, ~/Library/Android/sdk,
+# `which adb`, then Unity's bundled Android SDK.
+find_adb() {
+  if [ -n "${ADB:-}" ] && [ -x "$ADB" ]; then echo "$ADB"; return; fi
+  for CANDIDATE in \
+    "${ANDROID_HOME:-}/platform-tools/adb" \
+    "${ANDROID_SDK_ROOT:-}/platform-tools/adb" \
+    "$HOME/Library/Android/sdk/platform-tools/adb"; do
+    [ -x "$CANDIDATE" ] && echo "$CANDIDATE" && return
+  done
+  if command -v adb >/dev/null 2>&1; then command -v adb; return; fi
+  if [ -n "$UNITY" ]; then
+    UNITY_DIR=$(dirname "$(dirname "$(dirname "$(dirname "$UNITY")")")")
+    CANDIDATE="$UNITY_DIR/PlaybackEngines/AndroidPlayer/SDK/platform-tools/adb"
+    [ -x "$CANDIDATE" ] && echo "$CANDIDATE" && return
+  fi
+}
+ADB="$(find_adb)"
+
 OUTPUT="$SCRIPT_DIR/Build/Android/onesignal-demo.apk"
 LOG="$SCRIPT_DIR/Build/build-android.log"
 INSTALL=true
@@ -21,6 +52,7 @@ for arg in "$@"; do
 done
 
 pick_emulator() {
+  [ -z "$ADB" ] && echo "adb not found. Set ADB or ANDROID_HOME to your Android SDK." && exit 1
   LIST=$("$ADB" devices | awk '/emulator-[0-9]+[[:space:]]+device/{print $1}')
   COUNT=$(printf '%s\n' "$LIST" | grep -c . || true)
 

--- a/examples/demo/run-ios.sh
+++ b/examples/demo/run-ios.sh
@@ -6,7 +6,20 @@
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-UNITY="${UNITY_PATH:-/Applications/Unity/Hub/Editor/6000.3.6f1/Unity.app/Contents/MacOS/Unity}"
+
+# Auto-detect newest Unity 6000.x install under the Hub, unless UNITY_PATH is set.
+find_unity() {
+  if [ -n "${UNITY_PATH:-}" ]; then
+    echo "$UNITY_PATH"
+    return
+  fi
+  for d in $(ls -1 /Applications/Unity/Hub/Editor 2>/dev/null | sort -rV); do
+    BIN="/Applications/Unity/Hub/Editor/$d/Unity.app/Contents/MacOS/Unity"
+    [ -x "$BIN" ] && echo "$BIN" && return
+  done
+}
+UNITY="$(find_unity)"
+
 XCODE_DIR="$SCRIPT_DIR/Build/iOS"
 LOG="$SCRIPT_DIR/Build/build-ios.log"
 SCHEME="Unity-iPhone"


### PR DESCRIPTION
# Description
## One Line Summary
Fix Unity custom event properties losing nested objects/typed arrays on the way to the dashboard, plus add the GitHub Actions E2E workflow that runs the Appium suite against the demo app.


<img width="453" height="679" alt="Screenshot 2026-05-18 at 2 57 19 PM" src="https://github.com/user-attachments/assets/5d56f91c-2f16-4bad-9b22-eeb9ec0fd993" />
<img width="309" height="659" alt="Screenshot 2026-05-18 at 2 54 59 PM" src="https://github.com/user-attachments/assets/c083999e-edbf-470d-a556-1f83c10a3950" />
<img width="456" height="1005" alt="Screenshot 2026-05-18 at 2 47 28 PM" src="https://github.com/user-attachments/assets/5ba27c8c-5a60-445a-8d2d-ca8332c4504f" />
<img width="457" height="990" alt="Screenshot 2026-05-18 at 2 41 05 PM" src="https://github.com/user-attachments/assets/dd0e8694-9213-4073-822f-557198815a24" />

## Details

### Motivation
Linear: [SDK-4523 Unity Custom Events](https://linear.app/onesignal/issue/SDK-4523/unity-custom-events).

`OneSignal.User.TrackEvent(name, properties)` on Unity was mangling complex property values on both Android and iOS. Given:

```json
{
  "someNum": 123,
  "someFloat": 3.14159,
  "someObject": { "abc": "123", "nested": { "def": "456" }, "ghi": null },
  "someArray": [1, 2],
  "someMixedArray": [1, "2", { "abc": "123" }, null]
}
```

the dashboard received:

```json
{
  "someArray": ["1", "2"],
  "someObject": [null, null, null],
  "someMixedArray": ["1", "2", null, ""]
}
```

Two root causes:

1. **MiniJSON serializer** (`com.onesignal.unity.core/Runtime/Utilities/MiniJSON.cs`) checked `IList` before `IDictionary`. Any dict-like type that also implements `IList` (Newtonsoft's `JObject` is the common case, since `JContainer : IList<JToken>`) was serialized as a JSON array of its child `JProperty` items, producing `[null, null, null]` for a 3-key object.
2. **Android `ToMap`** (`com.onesignal.unity.android/Runtime/Utilities/AndroidJavaObjectExtensions.cs`) switched on the concrete type `Dictionary<string, object>` only. `JObject` is not `Dictionary<string, object>`, so it fell into the `IList` case and was treated as a JSON array.

Demo on top of that used `Newtonsoft.JsonConvert.DeserializeObject<Dictionary<string, object>>`, which is exactly the path that surfaces `JObject`/`JArray` wrappers.

### Scope
- Fixes nested object + nested array + typed-primitive (`int`, `double`) property encoding for `OneSignal.User.TrackEvent` on iOS and Android.
- Does not change the public Unity API. Direct callers using plain `Dictionary<string, object>` / `List<object>` continue to work as before.
- Adds the GitHub Actions E2E workflow that builds the Unity demo for Android emulator + iOS device and runs the shared Appium suite. Required for [SDK-4406] / future regression coverage of this fix.
- `run-android.sh` / `run-ios.sh` now auto-detect Unity (newest `6000.x` under the Hub) and `adb` (`ANDROID_HOME`, `~/Library/Android/sdk`, `which adb`, then Unity's bundled SDK) instead of hardcoding a specific editor version.

## Changes by file

| Area | File | Change |
|---|---|---|
| SDK | `com.onesignal.unity.core/Runtime/Utilities/MiniJSON.cs` | Check `IDictionary` before `IList` in `SerializeValue` |
| SDK | `com.onesignal.unity.android/Runtime/Utilities/AndroidJavaObjectExtensions.cs` | `ToMap` matches `IDictionary` before `IList` (replaces strict `Dictionary<string, object>`) |
| Demo | `examples/demo/Assets/Scripts/UI/Dialogs/TrackEventDialog.cs` | Parse JSON via SDK's MiniJSON (returns native `Dictionary<string, object>` / `List<object>`) instead of Newtonsoft, which returns `JObject`/`JArray` |
| Demo | `examples/demo/run-android.sh`, `run-ios.sh` | Auto-detect Unity + adb, with env-var overrides |
| CI | `.github/workflows/e2e.yml`, `.github/actions/create-demo-env/action.yml`, `examples/demo/Assets/Scripts/Editor/BuildScript.cs` | Add the Unity demo E2E workflow (Android emulator + iOS device) and demo `.env` action |

# Testing
## Manual testing
- Sent `TEST_JSON` (see `appium/tests/specs/10_event.spec.ts`) on Android emulator (Pixel 6, API 34) and iOS Simulator (iPhone 16 Pro, iOS 26.2). Verified on the OneSignal dashboard that `someObject` is a nested object, `someArray` contains numbers (not strings), and `someMixedArray` preserves its inner object/null entries.
- Verified the existing tracked-event behavior (top-level scalars + nulls) still round-trips correctly.
- Ran `./run-android.sh` and `./run-ios.sh` with no `UNITY_PATH` / `ADB` set and confirmed they discover the newest installed Unity `6000.x` and `~/Library/Android/sdk/platform-tools/adb`.

Made temp changes to custom events section e.g.
```
            // ---- TEMP: SDK-4523 native nested-properties sanity check ----
            // Bypasses the dialog/MiniJSON parser to confirm Dictionary<string,object>
            // and List<object> nested data round-trips correctly to the dashboard.
            section.Add(
                SectionBuilder.CreatePrimaryButton(
                    "TRACK NATIVE TEST",
                    "track_native_test_button",
                    TrackNativeTest
                )
            );
            // ---- END TEMP ----

            return section;
        }

        // ---- TEMP: SDK-4523 ----
        private void TrackNativeTest()
        {
            var props = new Dictionary<string, object>
            {
                ["someNum"] = 123,
                ["someFloat"] = 3.14159,
                ["someString"] = "abc",
                ["someBool"] = true,
                ["someObject"] = new Dictionary<string, object>
                {
                    ["abc"] = "123",
                    ["nested"] = new Dictionary<string, object> { ["def"] = "456" },
                    ["ghi"] = null,
                },
                ["someArray"] = new List<object> { 1, 2 },
                ["someMixedArray"] = new List<object>
                {
                    1,
                    "2",
                    new Dictionary<string, object> { ["abc"] = "123" },
                    null,
                },
                ["someNull"] = null,
            };

            _viewModel.TrackEvent("props_native", props);
        }
        // ---- END TEMP ----
    }
```
to test props_native vs just the json parsing.


## Unit / E2E
- The shared Appium spec at `appium/tests/specs/10_event.spec.ts` exercises `track_event_button` with this JSON. The E2E workflow added in this PR will run that spec against the demo on every PR going forward.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all REQUIRED sections above
   - [x] PR does one thing (Unity custom event property encoding + the E2E workflow that covers it)
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes (E2E suite via the new workflow)
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device

## Final pass
   - [x] Code is as readable as possible
   - [x] I have reviewed this PR myself
