### PR TITLE
chore(demo): harden iOS demo run script with preflight checks and simulator auto-boot

### DIFF
--- a/examples/demo/run-ios.sh
+++ b/examples/demo/run-ios.sh
@@ -37,6 +37,67 @@ for arg in "$@"; do
   esac
 done
 
+# Unity batchmode fails with misleading errors when these are missing
+# (Rosetta: instant death with an unrelated dialog; iOS Build Support:
+# 'build target was unsupported' buried in the log), so check up front.
+preflight_unity() {
+  if [ "$(uname -m)" = "arm64" ]; then
+    if [ ! -f /usr/libexec/rosetta/runtime ] && ! pgrep -q oahd 2>/dev/null; then
+      echo "Rosetta 2 is not installed — Unity's iOS build tooling requires it on Apple Silicon."
+      echo "Install it with: softwareupdate --install-rosetta --agree-to-license"
+      exit 1
+    fi
+  fi
+
+  # $UNITY is .../Hub/Editor/<version>/Unity.app/Contents/MacOS/Unity;
+  # the iOS module lives at .../Hub/Editor/<version>/PlaybackEngines/iOSSupport.
+  UNITY_ROOT="$(cd "$(dirname "$UNITY")/../../.." && pwd)"
+  if [ ! -d "$UNITY_ROOT/PlaybackEngines/iOSSupport" ]; then
+    echo "Unity iOS Build Support module not found at $UNITY_ROOT/PlaybackEngines/iOSSupport."
+    echo "Install 'iOS Build Support' via Unity Hub for $(basename "$UNITY_ROOT"), then re-run."
+    exit 1
+  fi
+}
+
+# Boot the newest available iPhone when nothing is booted yet.
+boot_newest_iphone() {
+  AVAIL=$(xcrun simctl list devices available -j \
+    | python3 -c "
+import json,re,sys
+d=json.load(sys.stdin)
+rows=[]
+for rt,devs in d['devices'].items():
+    m=re.search(r'iOS-(\d+)-(\d+)$',rt)
+    if not m: continue
+    ver=(int(m.group(1)),int(m.group(2)))
+    for dev in devs:
+        if dev.get('isAvailable') and dev['name'].startswith('iPhone'):
+            rows.append((ver,dev['name'],dev['udid']))
+rows.sort()
+for ver,name,udid in rows:
+    print(udid + '|' + name + '|' + '%d.%d' % ver)
+" 2>/dev/null || true)
+
+  if [ -z "$AVAIL" ]; then
+    echo "No booted simulators and no available iPhone simulators found."
+    echo "Install an iOS runtime via Xcode > Settings > Components, or boot a device with: xcrun simctl boot <device>"
+    exit 1
+  fi
+
+  echo "No booted simulators found. Available iPhones:"
+  printf '%s\n' "$AVAIL" | while IFS='|' read -r UDID NAME VER; do
+    printf '  %s (iOS %s)\n' "$NAME" "$VER"
+  done
+
+  LINE=$(printf '%s\n' "$AVAIL" | tail -1)
+  SIM_UDID=$(echo "$LINE" | cut -d'|' -f1)
+  SIM_NAME=$(echo "$LINE" | cut -d'|' -f2)
+  echo "Booting newest: $SIM_NAME (iOS $(echo "$LINE" | cut -d'|' -f3))..."
+  xcrun simctl boot "$SIM_UDID" 2>/dev/null || true
+  open -a Simulator
+  xcrun simctl bootstatus "$SIM_UDID" -b >/dev/null
+}
+
 pick_simulator() {
   LIST=$(xcrun simctl list devices booted -j \
     | python3 -c "
@@ -49,7 +110,7 @@ for r,devs in d['devices'].items():
 " 2>/dev/null || true)
   COUNT=$(printf '%s\n' "$LIST" | grep -c . || true)
 
-  [ "$COUNT" -eq 0 ] && echo "No booted simulators found. Boot one with: xcrun simctl boot <device>" && exit 1
+  [ "$COUNT" -eq 0 ] && boot_newest_iphone && return
   [ "$COUNT" -eq 1 ] && SIM_UDID=$(echo "$LIST" | cut -d'|' -f1) && SIM_NAME=$(echo "$LIST" | cut -d'|' -f2) && return
 
   echo "Multiple simulators booted — pick one:"
@@ -83,6 +144,7 @@ if [ "$SKIP_BUILD" = true ]; then
   echo "Skipping Unity build, using existing Xcode project"
 else
   [ ! -x "$UNITY" ] && echo "Unity not found at $UNITY — set UNITY_PATH" && exit 1
+  preflight_unity
   mkdir -p "$XCODE_DIR"
   echo "Generating Xcode project (IL2CPP / Simulator)..."
   echo "Log: $LOG"


### PR DESCRIPTION
## Summary

Improves `examples/demo/run-ios.sh` based on issues hit when running the Unity demo on iOS from a fresh machine for the first time. Each failure mode previously surfaced as a cryptic, hard-to-diagnose error; the script now fails fast with actionable guidance, or recovers automatically.

- **Rosetta 2 preflight (Apple Silicon):** Unity's iOS build tooling requires Rosetta 2, but without it Unity batchmode dies instantly with an unrelated dialog. The script now checks for it up front and prints the exact `softwareupdate --install-rosetta` remediation.
- **iOS Build Support preflight:** when the Unity editor lacks the iOS module, the build fails with `build target was unsupported` buried deep in the log. The script now verifies `PlaybackEngines/iOSSupport` exists for the resolved editor and tells the user to install it via Unity Hub.
- **Simulator auto-boot:** instead of exiting with `No booted simulators found` when nothing is booted, the script now lists available iPhones and boots the newest one (opening Simulator and waiting for boot), preserving the existing single-/multi-booted behavior.

## Test plan

- [ ] On Apple Silicon without Rosetta 2: script exits early with the install instruction.
- [ ] With an editor missing iOS Build Support: script exits early naming the module and version.
- [ ] With no simulator booted: script lists available iPhones, boots the newest, and proceeds.
- [ ] With a simulator already booted: behavior unchanged (uses it / prompts on multiple).
- [ ] Full happy path: `./run-ios.sh` builds, installs, and launches the demo on the simulator.

Made with [Cursor](https://cursor.com)