### PR TITLE
fix: [SDK-4746] register Android click listener lazily to replay cold-start clicks

### DIFF
--- a/com.onesignal.unity.android/Runtime/AndroidNotificationsManager.cs
+++ b/com.onesignal.unity.android/Runtime/AndroidNotificationsManager.cs
@@ -47,8 +47,36 @@ namespace OneSignalSDK.Android.Notifications
         }
 
         public event EventHandler<NotificationWillDisplayEventArgs> ForegroundWillDisplay;
-        public event EventHandler<NotificationClickEventArgs> Clicked;
         public event EventHandler<NotificationPermissionChangedEventArgs> PermissionChanged;
+
+        // Only set the native listener once
+        private bool _clickNativeListenerSet;
+
+        private EventHandler<NotificationClickEventArgs> _clicked;
+
+        /// <summary>
+        /// The native click listener is registered lazily on the first subscription. The native SDK
+        /// queues clicks that occur before a listener is added (e.g. a cold start from a notification
+        /// tap) and replays them when one is registered, so deferring registration until a C# handler
+        /// exists ensures those events are not dropped.
+        /// </summary>
+        public event EventHandler<NotificationClickEventArgs> Clicked
+        {
+            add
+            {
+                _clicked += value;
+
+                if (!_clickNativeListenerSet)
+                {
+                    _clickNativeListenerSet = true;
+                    _notifications.Call(
+                        "addClickListener",
+                        new InternalNotificationClickListener(this)
+                    );
+                }
+            }
+            remove { _clicked -= value; }
+        }
 
         public bool Permission
         {
@@ -91,7 +119,6 @@ namespace OneSignalSDK.Android.Notifications
                 "addForegroundLifecycleListener",
                 new InternalNotificationLifecycleListener(this)
             );
-            _notifications.Call("addClickListener", new InternalNotificationClickListener(this));
         }
 
         private sealed class InternalPermissionObserver : OneSignalAwaitableAndroidJavaProxy<bool>
@@ -194,7 +221,7 @@ namespace OneSignalSDK.Android.Notifications
                     result
                 );
 
-                EventHandler<NotificationClickEventArgs> handler = _parent.Clicked;
+                EventHandler<NotificationClickEventArgs> handler = _parent._clicked;
                 if (handler != null)
                 {
                     UnityMainThreadDispatch.Post(state => handler(_parent, args));

--- a/com.onesignal.unity.android/Runtime/AndroidNotificationsManager.cs
+++ b/com.onesignal.unity.android/Runtime/AndroidNotificationsManager.cs
@@ -52,30 +52,44 @@ namespace OneSignalSDK.Android.Notifications
         // Only set the native listener once
         private bool _clickNativeListenerSet;
 
+        private readonly object _clickRegistrationLock = new object();
+
         private EventHandler<NotificationClickEventArgs> _clicked;
 
         /// <summary>
         /// The native click listener is registered lazily on the first subscription. The native SDK
         /// queues clicks that occur before a listener is added (e.g. a cold start from a notification
         /// tap) and replays them when one is registered, so deferring registration until a C# handler
-        /// exists ensures those events are not dropped.
+        /// exists ensures those events are not dropped. The handler must be attached before the
+        /// native call, since the replay fires as soon as the listener registers. The flag is only
+        /// set after a successful native call so a transient failure can retry on the next
+        /// subscription.
         /// </summary>
         public event EventHandler<NotificationClickEventArgs> Clicked
         {
             add
             {
-                _clicked += value;
-
-                if (!_clickNativeListenerSet)
+                lock (_clickRegistrationLock)
                 {
-                    _clickNativeListenerSet = true;
-                    _notifications.Call(
-                        "addClickListener",
-                        new InternalNotificationClickListener(this)
-                    );
+                    _clicked += value;
+
+                    if (!_clickNativeListenerSet)
+                    {
+                        _notifications.Call(
+                            "addClickListener",
+                            new InternalNotificationClickListener(this)
+                        );
+                        _clickNativeListenerSet = true;
+                    }
                 }
             }
-            remove { _clicked -= value; }
+            remove
+            {
+                lock (_clickRegistrationLock)
+                {
+                    _clicked -= value;
+                }
+            }
         }
 
         public bool Permission

--- a/com.onesignal.unity.android/Runtime/AndroidNotificationsManager.cs
+++ b/com.onesignal.unity.android/Runtime/AndroidNotificationsManager.cs
@@ -75,10 +75,20 @@ namespace OneSignalSDK.Android.Notifications
 
                     if (!_clickNativeListenerSet)
                     {
-                        _notifications.Call(
-                            "addClickListener",
-                            new InternalNotificationClickListener(this)
-                        );
+                        try
+                        {
+                            _notifications.Call(
+                                "addClickListener",
+                                new InternalNotificationClickListener(this)
+                            );
+                        }
+                        catch
+                        {
+                            // Roll back so a failed subscription has no effect; retrying won't
+                            // add the same handler twice.
+                            _clicked -= value;
+                            throw;
+                        }
                         _clickNativeListenerSet = true;
                     }
                 }


### PR DESCRIPTION
# Description
## One Line Summary

Defer registering the native Android notification click listener until the first C# `Clicked` subscriber, so cold-start notification clicks are replayed instead of silently dropped.

## Details

### Motivation

Fixes #873. When an Android app is opened by tapping a push notification from a killed state (cold start), the click event — and its Additional Data — never reached the app.

The Android bridge registered the native click listener eagerly inside `OneSignal.Initialize()`. The native Android SDK queues a cold-start click and replays it the moment a listener is added, but at that point no C# `Clicked` handler was subscribed yet (apps subscribe after `Initialize()`, as our samples do), so the bridge discarded the replayed event.

This PR adopts the same lazy-registration pattern the iOS bridge already uses: the native `addClickListener` call now happens on the first C# `Clicked` subscription, after the handler is attached, so the native SDK's queued cold-start click replays into a live handler.

### Scope

Android only, notification click events only. `ForegroundWillDisplay` and `PermissionChanged` registration is unchanged. No public API changes — `OneSignal.Notifications.Clicked` behaves the same, except cold-start clicks now fire. iOS is untouched (it already worked this way).

# Testing
## Unit testing

None added — the repo has no unit test infrastructure, and this change is a thin JNI-registration ordering change.

## Manual testing

Ran a before-and-after comparison with the demo app (`examples/demo`), built with Unity 6000.3.6f1 (IL2CPP/ARM64) and installed on a Pixel 9 emulator (API 37, Google Play image). "Before" = `main`, "After" = this branch. To simulate real apps that subscribe to SDK events later than `Initialize()` (the stock demo subscribes ~100ms after, a window small enough that the replayed event usually sneaks through), a temporary 5-second delay was added before `RegisterSdkListeners()` in both builds.

### Reproduction steps

1. **Simulate late subscription.** In `examples/demo/Assets/Scripts/AppBootstrapper.cs`, add a delay before listener registration in `Start()` (this mimics apps that subscribe to `Clicked` in a later scene/frame, like the reporter's):

   ```csharp
   await System.Threading.Tasks.Task.Delay(5000);
   RegisterSdkListeners();
   ```

   Optionally, log the click payload in `OnNotificationClicked` via `Newtonsoft.Json.JsonConvert.SerializeObject(e.Notification.AdditionalData)` (note: `JsonUtility.ToJson` won't show `AdditionalData` — it can't serialize dictionaries).

2. **Build and install on a booted emulator** (Google Play image required for FCM):

   ```sh
   cd examples/demo && ./run-android.sh
   ```

3. **Subscribe the device.** Launch the app, accept the notification permission prompt, and wait for the push subscription to appear. Grab the subscription ID from the app UI (Push ID) or from logcat (`adb logcat | grep -o 'OneSignal-Subscription-Id=\[[a-f0-9-]*\]'`).

4. **Kill the app process** (kill only — `force-stop` would put the app in stopped state, which blocks FCM delivery):

   ```sh
   adb shell input keyevent KEYCODE_HOME
   adb shell am kill com.onesignal.example
   adb shell pidof com.onesignal.example   # should print nothing
   ```

5. **Send a push with Additional Data** to the subscription from step 3:

   ```sh
   curl -X POST https://onesignal.com/api/v1/notifications \
     -H "Content-Type: application/json" \
     -d '{"app_id":"<APP_ID>","include_subscription_ids":["<SUBSCRIPTION_ID>"],
          "headings":{"en":"Cold start test"},"contents":{"en":"Tap me"},
          "data":{"playback_data":"episode-42"}}'
   ```

6. **Tap the notification** from the shade (this cold-starts the app) and watch logcat:

   ```sh
   adb logcat | grep -E 'addClickListener|Notification clicked'
   ```

   - **On `main`:** `addClickListener` logs during `Initialize()`, then the listener registration log 5s later — but `Notification clicked` never appears. The event is dropped.
   - **On this branch:** `addClickListener` logs right after the 5s delay (first `Clicked +=`), immediately followed by `Notification clicked` with the `additionalData` payload.

### Results

**Before (bug reproduced)** — the native listener registers during `Initialize()`, the queued cold-start click replays into a null C# handler and is silently discarded:

```
09:28:44.165  NotificationsManager.addClickListener(...)   <- during Initialize()
09:28:49.373  [AppBootstrapper] Registering SDK listeners after 5s delay
              (no "Notification clicked" — event lost)
```

**After (fixed)** — the native listener registers on first `Clicked +=`, and the queued cold-start click replays immediately with Additional Data intact:

```
09:31:45.254  [AppBootstrapper] Registering SDK listeners after 5s delay
09:31:45.256  NotificationsManager.addClickListener(...)   <- lazy, after handler attached
09:31:45.296  [AppBootstrapper] Notification clicked: , additionalData: {"playback_data":"episode-42","test_key":"after-fix-delayed"}
```

**Regression checks on the fixed build (all passing):**
- Foreground receive: `ForegroundWillDisplay` fired and the notification displayed.
- Warm-start click (process alive, app backgrounded): `Clicked` fired immediately with `additionalData: {"test_key":"foreground"}`.
- Cold-start click: fired with data, as shown above.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
