### PR TITLE
fix: [SDK-4852] harden iOS click listener registration to match Android pattern

### DIFF
--- a/com.onesignal.unity.ios/Runtime/iOSNotificationsManager.cs
+++ b/com.onesignal.unity.ios/Runtime/iOSNotificationsManager.cs
@@ -91,23 +91,54 @@ namespace OneSignalSDK.iOS.Notifications
         public event EventHandler<NotificationWillDisplayEventArgs> ForegroundWillDisplay;
         public event EventHandler<NotificationPermissionChangedEventArgs> PermissionChanged;
 
-        // Only set the native listner once
+        // Only set the native listener once
         private bool _clickNativeListenerSet;
 
+        private readonly object _clickRegistrationLock = new object();
+
         private EventHandler<NotificationClickEventArgs> _clicked;
+
+        /// <summary>
+        /// The native click listener is registered lazily on the first subscription. The native SDK
+        /// queues clicks that occur before a listener is added (e.g. a cold start from a notification
+        /// tap) and replays them when one is registered, so deferring registration until a C# handler
+        /// exists ensures those events are not dropped. The handler must be attached before the
+        /// native call, since the replay fires as soon as the listener registers. The flag is only
+        /// set after a successful native call so a transient failure can retry on the next
+        /// subscription.
+        /// </summary>
         public event EventHandler<NotificationClickEventArgs> Clicked
         {
             add
             {
-                _clicked += value;
-
-                if (!_clickNativeListenerSet)
+                lock (_clickRegistrationLock)
                 {
-                    _clickNativeListenerSet = true;
-                    _oneSignalNotificationsSetClickCallback(_onClicked);
+                    _clicked += value;
+
+                    if (!_clickNativeListenerSet)
+                    {
+                        try
+                        {
+                            _oneSignalNotificationsSetClickCallback(_onClicked);
+                        }
+                        catch
+                        {
+                            // Roll back so a failed subscription has no effect; retrying won't
+                            // add the same handler twice.
+                            _clicked -= value;
+                            throw;
+                        }
+                        _clickNativeListenerSet = true;
+                    }
                 }
             }
-            remove { _clicked -= value; }
+            remove
+            {
+                lock (_clickRegistrationLock)
+                {
+                    _clicked -= value;
+                }
+            }
         }
 
         private static iOSNotificationsManager _instance;
@@ -211,7 +242,10 @@ namespace OneSignalSDK.iOS.Notifications
             NotificationClickEventArgs args = new NotificationClickEventArgs(notif, result);
 
             EventHandler<NotificationClickEventArgs> handler = _instance._clicked;
-            UnityMainThreadDispatch.Post(state => handler(_instance, args));
+            if (handler != null)
+            {
+                UnityMainThreadDispatch.Post(state => handler(_instance, args));
+            }
         }
 
         private static void _fillNotifFromObj(ref iOSDisplayableNotification notif, object notifObj)


### PR DESCRIPTION
# Description
## One Line Summary

Apply the same click-listener registration safeguards added to the Android bridge in #881 to the iOS bridge, so both platforms share the identical pattern.

## Details

### Motivation

#881 hardened the Android `Clicked` event accessor based on review feedback. The iOS bridge (`iOSNotificationsManager`) already used lazy native registration (which is why iOS never had the cold-start click drop), but had none of the safeguards:

1. The `add`/`remove` accessors were unsynchronized, so two threads subscribing concurrently could both pass the `_clickNativeListenerSet` check and register the native callback twice.
2. `_clickNativeListenerSet = true` was set *before* the native call, so a transient native-call failure left the flag stuck true with no listener registered — clicks silently lost for the app's lifetime with no retry.
3. A failed native call left the managed handler subscribed, so a caller retrying the subscription would add the same handler twice.

This PR applies the identical fixes: a private lock around both accessors, the flag set only after the native call returns, and a rollback (`_clicked -= value`) before rethrowing on failure.

It also adds the null-handler guard in `_onClicked` that the Android bridge already has — without it, a click arriving after all handlers are removed (the native listener is never unregistered) would throw a `NullReferenceException` on the Unity main thread.

### Scope

iOS only, notification click events only. No public API changes and no behavior change on any success path — the lazy registration timing is exactly as before. Android is untouched (already done in #881).

# Testing
## Unit testing

None added — the repo has no unit test infrastructure; this mirrors the reviewed and manually verified Android change from #881.

## Manual testing

Verified with the demo app built from this branch (Unity 6000.3.6f1, IL2CPP) on an iPhone 16 Pro simulator (iOS 18.1), using `xcrun simctl push` with a OneSignal-format payload containing additional data:

- App initializes normally; the first `Clicked +=` subscription registers the native callback through the new locked accessor without issues.
- Foreground receive path unchanged: C# `ForegroundWillDisplay` fired for each pushed notification and the notification displayed.
- Click path verified: tapping a pushed notification (app backgrounded) fired the C# `Clicked` handler, and the native SDK recorded the notification as a DIRECT influence.

The failure-path changes (concurrent first subscription, native call throwing) are not reachable in a normal run; correctness argued by symmetry with the reviewed Android implementation from #881.

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [x] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

