### PR TITLE
chore: [SDK-5128] add explicit Android notification grouping to demos

### DIFF
--- a/examples/demo-no-location/Assets/Scripts/NoLocationDemo.cs
+++ b/examples/demo-no-location/Assets/Scripts/NoLocationDemo.cs
@@ -12,6 +12,7 @@ public sealed class NoLocationDemo : MonoBehaviour
     private string _oneSignalAppId = "YOUR-ONESIGNAL-APP-ID";
 
     private const float ReferenceWidth = 393f;
+    private const string DemoAndroidGroup = "demo-group";
     private static readonly Color _backgroundColor = new Color32(248, 249, 250, 255);
     private static readonly Color _primaryColor = new Color32(229, 75, 77, 255);
     private static readonly Color _valueColor = new Color32(47, 52, 55, 255);
@@ -342,7 +343,8 @@ public sealed class NoLocationDemo : MonoBehaviour
             + $"\"app_id\":\"{_oneSignalAppId}\","
             + $"\"include_subscription_ids\":[\"{pushSubscriptionId}\"],"
             + "\"headings\":{\"en\":\"OneSignal No-Location Demo\"},"
-            + "\"contents\":{\"en\":\"This test push was sent without linking the location module.\"}"
+            + "\"contents\":{\"en\":\"This test push was sent without linking the location module.\"},"
+            + $"\"android_group\":\"{DemoAndroidGroup}\""
             + "}";
 
         using var request = new UnityWebRequest(

--- a/examples/demo/Assets/Scripts/Services/OneSignalApiService.cs
+++ b/examples/demo/Assets/Scripts/Services/OneSignalApiService.cs
@@ -18,6 +18,8 @@ namespace OneSignalDemo.Services
 
         private const string DefaultAndroidChannelId = "b3b015d9-c050-4042-8548-dcc34aa44aa4";
 
+        private const string DemoAndroidGroup = "demo-group";
+
         public void SetAppId(string appId) => _appId = appId;
 
         public string GetAppId() => _appId;
@@ -178,6 +180,7 @@ namespace OneSignalDemo.Services
                 ["include_subscription_ids"] = new JArray(subscriptionId),
                 ["headings"] = new JObject { ["en"] = title },
                 ["contents"] = new JObject { ["en"] = body },
+                ["android_group"] = DemoAndroidGroup,
             };
 
         // Retry while the OneSignal backend hasn't yet indexed the freshly


### PR DESCRIPTION
# Description

## One Line Summary

Send Unity demo notifications with a deterministic `android_group` so OneSignal manages grouping.

## Details

Linear: SDK-5128.

Android 16 auto-groups ungrouped notifications and tapping the system summary can skip OneSignal click data. Demo REST send paths now set `android_group` to `demo-group`, matching the React Native demo.

# Testing

- Payloads verified statically.
- Unity Editor was unavailable in this environment.
- Device tap-on-summary click data still needs a physical Android 16 check.

# Checklist

- [x] Demo send paths use a shared Android group key
- [x] No public API changes
